### PR TITLE
fix(react): allow >maxLength text field input

### DIFF
--- a/packages/react/src/components/BaseInput/index.tsx
+++ b/packages/react/src/components/BaseInput/index.tsx
@@ -64,6 +64,9 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((
 		validateOnDOMChange = defaultProps.validateOnDOMChange,
 		validators,
 		value: valueProp = defaultProps.value,
+		// pull out maxLength because it prevents user input past the given
+		// length, which is an anti-pattern according to our usage guidelines.
+		maxLength,
 		onChange,
 		onInput,
 		onDOMChange,
@@ -81,10 +84,10 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((
 
 	const validator = useValidation(validators);
 	const validate = React.useCallback((el: ValidationElement) => {
-		const errs = validator(el);
+		const errs = validator((maxLength) ? { ...el, maxLength } : el);
 		if (onValidate) onValidate(errs);
 		if (!errorsProp) setErrors(errs);
-	}, [validator, onValidate, errorsProp]);
+	}, [validator, onValidate, errorsProp, maxLength]);
 
 	/**
 	 * React's custom `onChange` event does not match the DOM's but it is where

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -11,11 +11,6 @@ import { prefix } from '../../config';
 
 export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
-interface TextInputCounterProps {
-	remaining: number;
-	max: number;
-}
-
 export interface TextFieldProps
 	extends FieldInfoCoreProps, FieldFeedbackCoreProps, BaseInputProps {
 	/** Text fields can be a limited subset of `<input>` types. */
@@ -36,7 +31,10 @@ export interface TextFieldProps
 	 * number of characters and returns the string or element that will be
 	 * rendered in the character counter slot.
 	 */
-	counter?: ({ remaining, max }: TextInputCounterProps) => React.ReactElement | string;
+	counter?: ({ remaining, max }: {
+		remaining: number;
+		max: number;
+	}) => React.ReactNode;
 	/** The base class name according to BEM conventions. */
 	baseName?: string;
 	/** The className for the TextField's `<input>` element. */
@@ -69,9 +67,10 @@ export interface TextFieldProps
 
 const defaultProps: Partial<TextFieldProps> = {
 	counterStart: 25,
-	counter: (
-		{ remaining, max }: TextInputCounterProps,
-	): string => `${remaining}/${max} characters remaining`,
+	counter: ({ remaining, max }) => {
+		if (remaining < 0) return null;
+		return `${remaining}/${max} characters remaining`;
+	},
 	type: 'text',
 };
 

--- a/packages/react/src/utilities/validation.ts
+++ b/packages/react/src/utilities/validation.ts
@@ -125,14 +125,19 @@ export const defaultValidators = ({
 			message: defaultMessages.valueMissing({}),
 		});
 	}
-	if (maxLength) {
+	if (maxLength && maxLength >= 0) {
 		validators.push({
 			name: 'tooLong',
 			test: validityStateTest('tooLong'),
 			message: defaultMessages.tooLong({ maxLength }),
 		});
+		validators.push({
+			name: 'tooLong',
+			test: (value) => value.length <= maxLength,
+			message: defaultMessages.tooLong({ maxLength }),
+		});
 	}
-	if (minLength) {
+	if (minLength && minLength >= 0) {
 		validators.push({
 			name: 'tooShort',
 			test: validityStateTest('tooShort'),


### PR DESCRIPTION
This prevents the `maxLength` from being passed to the `<input>` while still triggering the [`tooLong` constraint validation](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/tooLong). The end result is that users can now always input more than the `maxLength` characters but doing so will result in the "tooLong" error message appearing.

I didn't address the screen reader UX for the character counter, as I agree with @dnvargas25 that it's unclear what the best approach is.

closes #11