### PR TITLE
Core utilities

### DIFF
--- a/.sassdocrc.yaml
+++ b/.sassdocrc.yaml
@@ -7,6 +7,7 @@ groups:
   color: Color
   config: Config
   device: Device
+  helpers: Helpers
   motion: Motion
   reset: Reset
   spacing: Spacing

--- a/packages/core/src/_config.scss
+++ b/packages/core/src/_config.scss
@@ -22,10 +22,10 @@ $enable-duplicate-declarations: false !default;
 /// @type Boolean
 $enable-dark-scheme: false !default;
 
-/// Enable utility declarations. Only has an effect when using the full stylesheet.
-/// Utility declarations can always be used imperatively via `@include`.
+/// Enable helper declarations. Only has an effect when using the full stylesheet.
+/// Helper declarations can always be used imperatively via `@include`.
 /// @type Boolean
-$enable-utilities: true !default;
+$enable-helpers: true !default;
 
 /// Enable link styling for the specified selector context. Setting this to
 /// `null` will result in link styling being applied to all links. The default

--- a/packages/core/src/_config.scss
+++ b/packages/core/src/_config.scss
@@ -5,6 +5,8 @@
 /// @group Config
 ////
 
+@use 'sass:map';
+
 /// The expected browser font size, which determines the value of `1rem`. This is
 /// 16 in all browsers by default and shouldn't be changed under most scenarios.
 /// @type Number
@@ -26,6 +28,21 @@ $enable-dark-scheme: false !default;
 /// Helper declarations can always be used imperatively via `@include`.
 /// @type Boolean
 $enable-helpers: true !default;
+
+/// The default map of utilities for reference. All utilities are disabled by default.
+$-default-utilities: (
+	'color-families': false,
+	'color-roles': false,
+	'spacing': false,
+);
+
+/// A map of utility declarations that should be included in the full stylesheet.
+/// Only has an effect when using the full stylesheet. See `$-default-utilities`
+/// for a list of the possible utilities.
+/// Utility declarations can always be used imperatively via `@include`.
+/// @type Map
+$utilities: () !default;
+$utilities: map.merge($-default-utilities, $utilities);
 
 /// Enable link styling for the specified selector context. Setting this to
 /// `null` will result in link styling being applied to all links. The default

--- a/packages/core/src/a11y/index.scss
+++ b/packages/core/src/a11y/index.scss
@@ -69,11 +69,10 @@
 	}
 }
 
-/// Accessibility utility classes.
-/// Includes declarations for `.reduced-motion` and `.sr-only`.
-/// @group Utilities
-@mixin a11y-utilities {
-	@include util.declare('utilities-a11y') {
+/// Accessibility helper classes.
+/// @group Helpers
+@mixin a11y-helpers {
+	@include util.declare('helpers-a11y') {
 		.nds-reduced-motion {
 			@include reduce-motion;
 		}

--- a/packages/core/src/color/index.scss
+++ b/packages/core/src/color/index.scss
@@ -109,3 +109,59 @@ $warning-family: 'yellow' !default;
 /// The grade that defines the "midpoint" of the warning family. For instance,
 /// setting this to `60` will cause the `warning` token to reference `warning-60`.
 $warning-grade: 60 !default;
+
+$roles: (
+	(name: 'primary', grade: $primary-grade),
+	(name: 'base', grade: $base-grade),
+	(name: 'disabled', grade: $disabled-grade),
+	(name: 'error', grade: $error-grade),
+	(name: 'success', grade: $success-grade),
+	(name: 'warning', grade: $warning-grade),
+);
+
+/// Utility declarations for color families.
+/// @group Utilities
+@mixin color-family-utilities {
+	@include util.declare('utilities-color-families') {
+		@each $name, $val in $families {
+			@for $g from 1 to 10 {
+				$grade: $g * 10;
+
+				.nds-bg-#{$name}-#{$grade} {
+					background-color: var(--nds-#{$name}-#{$grade}) !important;
+				}
+
+				.nds-color-#{$name}-#{$grade} {
+					color: var(--nds-#{$name}-#{$grade}) !important;
+				}
+			}
+		}
+	}
+}
+
+/// Utility declarations for color roles.
+/// @group Utilities
+@mixin color-role-utilities {
+	@include util.declare('utilities-color-roles') {
+		@each $role in $roles {
+			$name: map.get($role, 'name');
+			$grade: map.get($role, 'grade');
+			$steps: (null, 'light', 'lighter', 'dark', 'darker');
+
+			@if $grade {
+				@each $step in $steps {
+					$token: if($step, '#{$name}-color-#{$step}', '#{$name}-color');
+					$class: if($step, '#{$name}-#{$step}', $name);
+
+					.nds-bg-#{$class} {
+						background-color: var(--nds-#{$token}) !important;
+					}
+
+					.nds-color-#{$class} {
+						color: var(--nds-#{$token}) !important;
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/core/src/main.scss
+++ b/packages/core/src/main.scss
@@ -1,5 +1,7 @@
 // The full design system as one stylesheet.
 
+@use 'sass:map';
+
 // forward the whole thing so the variables/mixins/functions can be used downstream
 @forward '.';
 
@@ -23,7 +25,21 @@
 @include nds.textfield-style;
 @include nds.tooltip-style;
 
-// Utilities
-@if nds.$enable-utilities {
-	@include nds.a11y-utilities;
+// Helpers - declarations that set a composed style
+@if nds.$enable-helpers {
+	@include nds.a11y-helpers;
+}
+
+// Utilities - declarations that only set one property
+
+@if map.get(nds.$utilities, 'color-families') {
+	@include nds.color-family-utilities;
+}
+
+@if map.get(nds.$utilities, 'color-roles') {
+	@include nds.color-role-utilities;
+}
+
+@if map.get(nds.$utilities, 'spacing') {
+	@include nds.spacing-utilities;
 }

--- a/packages/core/src/spacing/index.scss
+++ b/packages/core/src/spacing/index.scss
@@ -119,3 +119,34 @@ $-spacer-roles: (
 @function spacer($role: 'block') {
 	@return var(--nds-#{util.from-role($role, 'spacing', $-spacer-roles)});
 }
+
+/// Utility declarations for spacing tokens.
+/// @group Utilities
+@mixin spacing-utilities {
+	@include util.declare('utilities-spacing') {
+		$-spacers: ('0', '1px', '2px', '1', '2', '3', '4', '5', '6', '8', '10', '12');
+		$-dirs: (
+			't': ('top'),
+			'r': ('right'),
+			'b': ('bottom'),
+			'l': ('left'),
+			'x': ('left', 'right'),
+			'y': ('top', 'bottom'),
+		);
+
+		@each $spacer in $-spacers {
+			@each $dir, $props in $-dirs {
+				.nds-p#{$dir}#{$spacer} {
+					@each $prop in $props {
+						padding-#{$prop}: var(--nds-spacing-#{$spacer}) !important;
+					}
+				}
+				.nds-m#{$dir}#{$spacer} {
+					@each $prop in $props {
+						margin-#{$prop}: var(--nds-spacing-#{$spacer}) !important;
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This introduces a WIP utilities API for `@wwnds/core`.

Utilities are generally single-property declarations that can be used in HTML to set tokens via classes. Utilities can selectively be enabled on build via the `@use...with` Sass syntax.

```scss
@use '@wwnds/core/full' with (
  $utilities: ('color-families': true),
);
// results in output like:
// .nds-bg-teal-30 {
//   background-color: var(--nds-teal-30) !important;
// }
// .nds-color-teal-30 {
//   color: var(--nds-teal-30) !important;
// }
```