### PR TITLE
Fix/13 textfield cursor

### DIFF
--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -7,7 +7,9 @@ import {
 	text,
 	select,
 } from '@storybook/addon-knobs';
-import { TextField, TextFieldType, TextFieldProps } from '.';
+import {
+	TextField, TextFieldUncontrolled, TextFieldType, TextFieldProps,
+} from '.';
 import { Button, ButtonProps } from '../Button';
 import { Icon, IconProps } from '../Icon';
 import { useValidation } from '../../utilities';
@@ -18,10 +20,12 @@ export default {
 	decorators: [withKnobs],
 };
 
+export const Test = (): JSX.Element => <TextField>TextField</TextField>;
+
 export const Default: React.FunctionComponent = () => {
 	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
 	return (
-		<TextField
+		<TextFieldUncontrolled
 			description='The default Text Field has a type of "text"'
 			disabled={boolean('Disabled', false)}
 
@@ -33,7 +37,7 @@ export const Default: React.FunctionComponent = () => {
 			optionalIndicator={indicator === 'optional'}
 		>
 			{ text('Label', 'Default Text Field') }
-		</TextField>
+		</TextFieldUncontrolled>
 	);
 };
 
@@ -93,44 +97,44 @@ export const EveryType: React.FunctionComponent = () => {
 
 	return (
 		<>
-			<TextField type="email" {...props}>Email</TextField>
-			<TextField type="number" {...props}>Number</TextField>
-			<TextField type="password" {...props}>Password</TextField>
-			<TextField type="search" {...props}>Search</TextField>
-			<TextField type="tel" {...props}>Telephone</TextField>
-			<TextField type="text" {...props}>Text</TextField>
-			<TextField type="url" {...props}>URL</TextField>
+			<TextFieldUncontrolled type="email" {...props}>Email</TextFieldUncontrolled>
+			<TextFieldUncontrolled type="number" {...props}>Number</TextFieldUncontrolled>
+			<TextFieldUncontrolled type="password" {...props}>Password</TextFieldUncontrolled>
+			<TextFieldUncontrolled type="search" {...props}>Search</TextFieldUncontrolled>
+			<TextFieldUncontrolled type="tel" {...props}>Telephone</TextFieldUncontrolled>
+			<TextFieldUncontrolled type="text" {...props}>Text</TextFieldUncontrolled>
+			<TextFieldUncontrolled type="url" {...props}>URL</TextFieldUncontrolled>
 		</>
 	);
 };
 
 export const WithMaxLength: React.FunctionComponent = () => (
-	<TextField
+	<TextFieldUncontrolled
 		maxLength={number('Maximum length', 10)}
 		counterStart={number('Start counter at', 8)}
 		onCount={action('onCount')}
 		validateOnChange
 	>
 		Text Field with max length
-	</TextField>
+	</TextFieldUncontrolled>
 );
 
 export const WithAddonBefore: React.FunctionComponent = () => (
-	<TextField
+	<TextFieldUncontrolled
 		type="text"
 		addonBefore={<Button variant="ghost">Do something</Button>}
 	>
 		Text field with a button addon
-	</TextField>
+	</TextFieldUncontrolled>
 );
 
 export const WithAddonAfter: React.FunctionComponent = () => (
-	<TextField
+	<TextFieldUncontrolled
 		type="text"
 		addonAfter={<Button variant="outline">Do something else</Button>}
 	>
 		Text field with a button addon
-	</TextField>
+	</TextFieldUncontrolled>
 );
 
 const show: ButtonProps = {

--- a/packages/react/src/components/TextField/index.test.tsx
+++ b/packages/react/src/components/TextField/index.test.tsx
@@ -79,20 +79,19 @@ test('invalid input is reflected in both constraint validation and in ARIA', (t)
 	t.is(input.getAttribute('aria-invalid'), 'true');
 });
 
-test('the character counter counts down as the user types when `maxLength` is defined', (t) => {
-	render(<TextField maxLength={10}>{ defaultLabel }</TextField>);
-
-	t.truthy(screen.queryByText('10/10 characters remaining'));
-
-	fireEvent.change(screen.getByLabelText(defaultLabel), { target: { value: 'abc' } });
+test('the character counter counts down as `value` changes when `maxLength` is defined', (t) => {
+	render(<TextField maxLength={10} value='abc'>{ defaultLabel }</TextField>);
 	t.truthy(screen.getByText('7/10 characters remaining'));
 });
 
 test('the character counter doesn\'t appear until the `counterStart` threshold is met', (t) => {
-	render(<TextField maxLength={10} counterStart={8}>{ defaultLabel }</TextField>);
-
+	const { rerender } = render((
+		<TextField maxLength={10} counterStart={8}>{ defaultLabel }</TextField>
+	));
 	t.falsy(screen.queryByText('10/10 characters remaining'));
 
-	fireEvent.change(screen.getByLabelText(defaultLabel), { target: { value: 'abc' } });
+	rerender((
+		<TextField maxLength={10} counterStart={8} value='abc'>{ defaultLabel }</TextField>
+	));
 	t.truthy(screen.getByText('7/10 characters remaining'));
 });

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -237,3 +237,25 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
 		</div>
 	);
 });
+
+/**
+ * An uncontrolled variant of the `TextField` component. The `value` prop doesn't
+ * exist on this version, as it is managed internally. Use when the value does not
+ * need to be controlled via React state, such as prototyping or when
+ * values are submitted with native APIs like
+ * [HTMLFormElement.submit()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit).
+ */
+export const TextFieldUncontrolled = (props: Omit<TextFieldProps, 'value'>): JSX.Element => {
+	const [value, setValue] = React.useState('');
+	return (
+		<TextField
+			value={value}
+			onChange={(e) => {
+				setValue(e.target.value);
+				const { onChange } = props;
+				if (onChange) onChange(e);
+			}}
+			{...props}
+		/>
+	);
+};

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -116,10 +116,9 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
 		maxLength,
 		required,
 		type = defaultProps.type,
-		value: valueProp = '',
+		value,
 
 		// event callbacks
-		onChange,
 		onCount,
 		onDOMChange,
 		onValidate,
@@ -128,13 +127,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
 		...inputProps
 	}: TextFieldProps, ref,
 ) => {
-	const [value, setValue] = React.useState(valueProp);
 	const [errors, setErrors] = React.useState(errorsProp);
-	const [remaining, setRemaining] = React.useState(maxLength);
-
-	// treat prop versions of errors and value as source of truth
-	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
-	React.useEffect(() => setValue(valueProp), [valueProp]);
 
 	// ids stored as refs since they shouldn't change between renders
 	const { current: id } = React.useRef(idProp || uniqueId(`${baseName}-`));
@@ -143,10 +136,14 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
 	const { current: errId } = React.useRef(errIdProp || `${id}-err`);
 	const { current: inputId } = React.useRef(`${id}-input`);
 
-	React.useEffect(() => {
+	// treat prop version of errors as source of truth
+	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
+
+	const remaining = React.useMemo(() => {
 		if (maxLength) {
-			setRemaining(maxLength - value.toString().length);
+			return maxLength - (value || '').toString().length;
 		}
+		return undefined;
 	}, [value, maxLength]);
 
 	React.useEffect(() => {
@@ -154,11 +151,6 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
 	}, [onCount, remaining]);
 
 	const isValid = React.useMemo(() => Boolean(!errors || errors.length === 0), [errors]);
-
-	const changeHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
-		if (onChange) onChange(e);
-		else setValue(e.currentTarget.value);
-	};
 
 	const validateHandler = (e: string[]): void => {
 		if (onValidate) onValidate(e);
@@ -213,9 +205,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
 				{ createFieldAddons(addonBefore) }
 				<BaseInput
 					ref={ref}
-					value={value}
 					errors={errors}
-					onChange={changeHandler}
 					onDOMChange={onDOMChange}
 					onValidate={validateHandler}
 					id={inputId}


### PR DESCRIPTION
This change effectively makes `value` and `onChange` required in `TextField`, as it can no longer be uncontrolled. In other words, setting `<TextField>My field</TextField>` will result in a field where the user can't input anything.

To address the need for an uncontrolled text field (if one exists), I've added a `TextFieldUncontrolled` component that can only be operated in an uncontrolled fashion.

Closes #11.