### PR TITLE
Callout refactor

### DIFF
--- a/packages/core/src/components/callout/index.scss
+++ b/packages/core/src/components/callout/index.scss
@@ -142,6 +142,18 @@
 		transform: translateX(calc(-100% + var(--nds-button-padding-x) - 2px));
 	}
 
+	.nds-callout[data-border~=top]:not(.nds-callout--no-title) & {
+		transform:
+			translateY(calc(var(--nds-callout-padding-y) - var(--nds-button-padding-y) - var(--nds-callout-border-width)))
+			translateX(calc(-1 * (var(--nds-callout-padding-x) - var(--nds-button-padding-x) + 2px)));
+	}
+
+	.nds-callout[data-border~=right]:not(.nds-callout--no-title) & {
+		transform:
+			translateY(calc(var(--nds-callout-padding-y) - var(--nds-button-padding-y)))
+			translateX(calc(-1 * (var(--nds-callout-padding-x) - var(--nds-button-padding-x) - var(--nds-callout-border-width) + 2px)));
+	}
+
 	&:not(:disabled):not(.disabled):hover,
 	&:not(:disabled):not(.disabled).hover {
 		background-color: var(--nds-callout-color-dark);

--- a/packages/core/src/components/callout/index.scss
+++ b/packages/core/src/components/callout/index.scss
@@ -108,6 +108,10 @@
 	margin-right: spacing.spacer('0.75rem');
 	color: var(--nds-callout-icon-color);
 	flex-grow: 0;
+
+	svg {
+		vertical-align: text-bottom;
+	}
 }
 
 @mixin title {


### PR DESCRIPTION
- adjusts icon positioning after shrinking down size, uses `vertical-align: text-bottom` 
- adjusts dismiss button to account for border widths on `border: top` and `border: right` when the title exists. 