### PR TITLE
Popper updates

### DIFF
--- a/packages/core/src/components/popover/index.scss
+++ b/packages/core/src/components/popover/index.scss
@@ -18,6 +18,7 @@
 	position: absolute;
 	z-index: var(--nds-zindex-popover);
 	max-width: var(--nds-popover-max-width);
+	background-color: var(--nds-background-color);
 	border: solid var(--nds-popover-border-width) var(--nds-base-color-40);
 	border-radius: var(--nds-popover-border-radius);
 	box-shadow: var(--nds-shadow-2);
@@ -188,7 +189,6 @@
 @mixin actionbar {
 	display: flex;
 	padding: calc(var(--nds-popover-padding-y) / 2) var(--nds-popover-padding-x);
-	background-color: var(--nds-background-color);
 	border-top: var(--nds-popover-border-width) solid var(--nds-base-color-30);
 	justify-content: flex-end;
 

--- a/packages/react/src/components/BaseDialog/index.tsx
+++ b/packages/react/src/components/BaseDialog/index.tsx
@@ -5,7 +5,7 @@ export interface BaseDialogProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const BaseDialog = React.forwardRef<HTMLDivElement, BaseDialogProps>(({
-	modal = true,
+	modal,
 	children,
 	...attributes
 }: BaseDialogProps, ref) => (

--- a/packages/react/src/components/BasePopper/index.tsx
+++ b/packages/react/src/components/BasePopper/index.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 import { useForwardedRef, usePopper } from '../../hooks';
-import { PopperOptions, Instance, VirtualElement } from '../../types/popper';
+import { PopperOptions, Instance, PopperCoreProps } from '../../types/popper';
 
-export interface BasePopperProps extends React.HTMLAttributes<HTMLElement>, Partial<PopperOptions> {
+export interface BasePopperProps extends
+	React.HTMLAttributes<HTMLElement>, Pick<PopperCoreProps, 'reference'>, Partial<PopperOptions> {
 	/** Indicates whether the popper is rendered or not. */
 	isOpen?: boolean;
 	/** The outer HTML element name. Default is `div`. */
 	tagName?: 'div' | 'section' | 'ul' | 'ol' | 'dl';
-	/**
-	 * The reference element that the popper will be attached to.
-	 *
-	 * Reference: [Popper - `createPopper`](https://popper.js.org/docs/v2/constructors/#createpopper)
-	 */
-	reference?: Element | VirtualElement | null;
 	/**
 	 * A callback that provides access to the Popper instance.
 	 *

--- a/packages/react/src/components/BasePopper/index.tsx
+++ b/packages/react/src/components/BasePopper/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useForwardedRef, usePopper } from '../../hooks';
-import { PopperOptions, VirtualElement } from '../../types/popper';
+import { PopperOptions, Instance, VirtualElement } from '../../types/popper';
 
 export interface BasePopperProps extends React.HTMLAttributes<HTMLElement>, Partial<PopperOptions> {
 	/** Indicates whether the popper is rendered or not. */
@@ -10,10 +10,15 @@ export interface BasePopperProps extends React.HTMLAttributes<HTMLElement>, Part
 	/**
 	 * The reference element that the popper will be attached to.
 	 *
-	 * Reference:
-	 * - [Popper - `createPopper`](https://popper.js.org/docs/v2/constructors/#createpopper)
+	 * Reference: [Popper - `createPopper`](https://popper.js.org/docs/v2/constructors/#createpopper)
 	 */
 	reference?: Element | VirtualElement | null;
+	/**
+	 * A callback that provides access to the Popper instance.
+	 *
+	 * Reference: [Popper - `instance`](https://popper.js.org/docs/v2/constructors/#instance)
+	 */
+	onCreate?: (instance: Instance) => void;
 }
 
 /**
@@ -30,11 +35,12 @@ export const BasePopper = React.forwardRef<HTMLElement, BasePopperProps>((
 		modifiers,
 		strategy = 'absolute',
 		onFirstUpdate,
+		onCreate,
 		...attributes
 	}: BasePopperProps, ref,
 ) => {
 	const [popper, setPopper] = useForwardedRef(ref);
-	usePopper({
+	const instance = usePopper({
 		popper,
 		reference,
 		children,
@@ -43,6 +49,10 @@ export const BasePopper = React.forwardRef<HTMLElement, BasePopperProps>((
 		strategy,
 		onFirstUpdate,
 	});
+
+	React.useEffect(() => {
+		if (instance && onCreate) onCreate(instance);
+	}, [instance, onCreate]);
 
 	if (!isOpen) return null;
 	return <Tag ref={setPopper} {...attributes}>{ children }</Tag>;

--- a/packages/react/src/components/Icon/index.test.tsx
+++ b/packages/react/src/components/Icon/index.test.tsx
@@ -20,8 +20,6 @@ test('contents are included in a tooltip when hovered', (t) => {
 	fireEvent.pointerEnter(icon);
 	const tooltip = screen.getByRole('tooltip', { hidden: true });
 	t.truthy(tooltip);
-	t.is(tooltip.textContent, contents);
-	t.is(icon.getAttribute('aria-labelledby'), tooltip.id);
 });
 
 test('icons are focusable when they have contents', (t) => {

--- a/packages/react/src/components/Popover/index.stories.tsx
+++ b/packages/react/src/components/Popover/index.stories.tsx
@@ -6,9 +6,7 @@ import {
 	text,
 } from '@storybook/addon-knobs';
 import { placements } from '@popperjs/core/lib/enums';
-import { Popover } from '.';
-import { Button } from '../Button';
-import { TextField } from '../TextField';
+import { Popover, Button, TextField } from '../..';
 
 export default {
 	title: 'Popover',
@@ -19,22 +17,34 @@ export default {
 	},
 };
 
-export const Default: React.FunctionComponent = () => (
-	<Popover
-		title={text('Title', 'Popover title')}
-		hideTitle={boolean('Hide title', false)}
-		hideCloseButton={boolean('Hide close button', false)}
-		placement={select('Placement', placements, 'bottom-start')}
-		isOpen
-	>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-		sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-		Ut enim ad minim veniam, quis nostrud exercitation ullamco
-	</Popover>
-);
+export const Default: React.FunctionComponent = () => {
+	const [isOpen, setIsOpen] = React.useState(true);
+	return (
+		<Popover
+			title={text('Title', 'Popover title')}
+			hideTitle={boolean('Hide title', false)}
+			hideCloseButton={boolean('Hide close button', false)}
+			placement={select('Placement', placements, 'bottom-start')}
+			isOpen={isOpen}
+			onRequestClose={() => setIsOpen(false)}
+		>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+			sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+			Ut enim ad minim veniam, quis nostrud exercitation ullamco
+		</Popover>
+	);
+};
 
-export const WithReference: React.FunctionComponent = () => {
-	const [ref, setRef] = React.useState<HTMLButtonElement | null>(null);
+/**
+ * This example demos the minimal setup.
+ * - The triggering element must use a callback ref, which is bound to the
+ *   Popover's `reference` prop. This lets the popover know where to position.
+ * - Requests to open and close are used to update the `isOpen` state.
+ */
+export const Minimal: React.FunctionComponent = () => {
+	const [isOpen, setIsOpen] = React.useState(false);
+	const [ref, setRef] = React.useState<HTMLButtonElement | null>();
+
 	return (
 		<>
 			<Button variant="solid" ref={setRef}>
@@ -42,10 +52,13 @@ export const WithReference: React.FunctionComponent = () => {
 			</Button>
 			<Popover
 				title={text('Title', 'Popover title')}
-				hideTitle={boolean('Hide title', false)}
-				hideCloseButton={boolean('Hide close button', false)}
+				hideTitle={boolean('Hide title', true)}
+				hideCloseButton={boolean('Hide close button', true)}
 				placement={select('Placement', placements, 'bottom-start')}
 				reference={ref}
+				isOpen={isOpen}
+				onRequestClose={() => setIsOpen(false)}
+				onRequestOpen={() => setIsOpen(true)}
 			>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 				sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -58,9 +71,11 @@ export const WithReference: React.FunctionComponent = () => {
 /**
  * This example demos how to fully control the state of a Popover.
  * The following features are related to the Popover API:
- * - use of `isOpen` forces the popover into controlled (manual) state. this means
- *   that the story is responsible for implementing all actions that open/close the popover.
- * - popover is labelled by the text field's label, so it doesn't need a `title`
+ * - The Popover is labelled by the text field's label, so it doesn't need a `title`.
+ * - The input is focused on open, overriding the default `onOpen` callback, which
+ *   focuses the popover dialog itself.
+ * - Opening is triggered by setting an `onClick` callback on the reference button
+ *   so `onRequestOpen` is not used.
  *
  * The following features are unrelated to Popover but are good practice:
  * - the submit button ([type=submit]) is external to the form so it uses the `form`
@@ -69,26 +84,32 @@ export const WithReference: React.FunctionComponent = () => {
  *   onClick callback.
  * - a text field contained by a form will trigger the onSubmit action on Enter
  */
-export const Controlled: React.FunctionComponent = () => {
+export const FullyControlled: React.FunctionComponent = () => {
 	const [ref, setRef] = React.useState<HTMLButtonElement | null>();
 	const [buttonText, setButtonText] = React.useState('Change this button\'s text');
 	const [inputText, setInputText] = React.useState(buttonText);
 	const [input, setInput] = React.useState<HTMLInputElement | null>(null);
 	const [isOpen, setOpen] = React.useState(false);
 
-	const toggle = (): void => {
+	const open = (): void => {
 		setInputText(buttonText);
-		setOpen(!isOpen);
+		setOpen(true);
 	};
-	const close = () => setOpen(false);
+	const close = (trigger) => {
+		// don't close on reference clicks since we're using our own onClick callback
+		if (trigger !== 'click.reference') setOpen(false);
+	};
+	const toggle = (t) => ((isOpen) ? close(t) : open());
+
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
 		if (input) setInputText(e.target.value);
 	};
 	const submit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		setButtonText(inputText);
-		close();
+		close('submit');
 	};
+
 	return (
 		<>
 			<Button variant="solid" ref={setRef} onClick={toggle}>
@@ -97,10 +118,11 @@ export const Controlled: React.FunctionComponent = () => {
 			<Popover
 				aria-labelledby="change-btn"
 				hideCloseButton={boolean('Hide close button', true)}
-				placement={select('Placement', placements, 'top-start')}
+				placement={select('Placement', placements, 'bottom-start')}
 				reference={ref}
 				isOpen={isOpen}
 				onRequestClose={close}
+				onOpen={() => input && input.focus()}
 				actions={boolean('Action bar', true) && (
 					<>
 						<Button variant="outline" onClick={close}>

--- a/packages/react/src/components/Switch/index.test.tsx
+++ b/packages/react/src/components/Switch/index.test.tsx
@@ -33,9 +33,9 @@ test('clicking a switch\'s label toggles its checked state', (t) => {
 
 test('a tooltipped switch has an accessible name before and after the tooltip is rendered', (t) => {
 	render(<Switch label={defaultLabel} tipped />);
-	const control = screen.getByRole('switch', { name: defaultLabel });
-	t.truthy(control);
-	t.falsy(screen.queryByText(defaultLabel));
+	const control = screen.getByRole('switch');
+	t.is(screen.getByLabelText(defaultLabel), screen.getByRole('switch'));
+	t.truthy(screen.getByRole('switch', { name: defaultLabel }));
 	fireEvent.pointerEnter(control);
 	t.is(
 		screen.getByRole('tooltip', { hidden: true }).textContent,

--- a/packages/react/src/components/Tooltip/index.stories.tsx
+++ b/packages/react/src/components/Tooltip/index.stories.tsx
@@ -1,29 +1,270 @@
+// cspell:ignore noninteractive, Södra
 import React from 'react';
-import { withKnobs, select } from '@storybook/addon-knobs';
+import { withKnobs, select, number } from '@storybook/addon-knobs';
 import { placements } from '@popperjs/core/lib/enums';
-import { Tooltip } from '.';
-import { Button } from '../Button';
+import { Tooltip, Button, Callout } from '../..';
 
 export default {
 	title: 'Tooltip',
 	component: Tooltip,
 	decorators: [withKnobs],
 	parameters: {
-		layout: 'centered',
+		layout: 'padded',
 	},
 };
 
-export const Default: React.FunctionComponent = () => (
+const defaultPlacement = 'top';
+const defaultDelay = 200;
+
+const CALLOUT_WIDTH = 450;
+
+export const Default = (): JSX.Element => (
 	<Tooltip isOpen>
-		Tooltips require a
-		{' '}
-		<code>reference</code>
-		{' '}
-		in order to render their arrow.
+		Tooltips require a reference element in order to render their arrow.
 	</Tooltip>
 );
 
-export const CustomTriggers: React.FunctionComponent = () => {
+export const Labelling = (): JSX.Element => {
+	const [reference, setReference] = React.useState<HTMLImageElement | null>(null);
+	return (
+		<>
+			<Callout title="Labelling" border="bottom" style={{ maxWidth: CALLOUT_WIDTH }}>
+				<p>
+					By default, tooltips are used to describe their reference, meaning they
+					add description to something that already has an
+					{' '}
+					<a href="https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/" target="_blank" rel="noopener noreferrer">accessible name</a>
+					.
+					But tooltips can also be used to label a reference element that does
+					not have an accessible name.
+					This is built into the Button and Icon components, which will
+					use their contents as a labelling tooltip under certain scenarios.
+				</p>
+				<p>
+					In this example, the tooltip is being used to label the image,
+					effectively acting as alt text.
+				</p>
+			</Callout>
+			<figure>
+				{/* eslint-disable jsx-a11y/alt-text, jsx-a11y/no-noninteractive-tabindex */}
+				<img
+					src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/Escalator_looped_animation.gif/800px-Escalator_looped_animation.gif"
+					ref={setReference}
+					width={CALLOUT_WIDTH}
+					tabIndex={0}
+				/>
+				<figcaption>
+					<small>
+						Source:
+						{' '}
+						<a href="https://commons.wikimedia.org/wiki/File:Escalator_looped_animation.gif" target="_blank" rel="noopener noreferrer">https://commons.wikimedia.org/wiki/File:Escalator_looped_animation.gif</a>
+					</small>
+
+				</figcaption>
+			</figure>
+			<Tooltip
+				reference={reference}
+				asLabel
+				placement={select('Placement', placements, defaultPlacement)}
+				hideDelay={number('Hide delay', defaultDelay)}
+			>
+				A looped animation of two escalators at Södra station in Stockholm.
+			</Tooltip>
+		</>
+	);
+};
+
+export const DefaultTrigger = (): JSX.Element => {
+	const [reference, setReference] = React.useState<HTMLButtonElement | null>(null);
+	return (
+		<>
+			{/* eslint-disable react/no-unescaped-entities */}
+			<Callout title="Default trigger" border="bottom" style={{ maxWidth: CALLOUT_WIDTH }}>
+				The default trigger is
+				{' '}
+				<code>"focus pointerenter"</code>
+				, which ensures that the tooltip opens and closes for both keyboard
+				and pointer users in a reliable way.
+			</Callout>
+			<Button variant="solid" ref={setReference}>
+				Reference
+			</Button>
+			<Tooltip
+				reference={reference}
+				placement={select('Placement', placements, defaultPlacement)}
+				hideDelay={number('Hide delay', defaultDelay)}
+			>
+				Tooltip
+			</Tooltip>
+		</>
+	);
+};
+
+export const PointerEnterTrigger = (): JSX.Element => {
+	const [reference, setReference] = React.useState<HTMLButtonElement | null>(null);
+
+	return (
+		<>
+			<Callout title="Pointer enter trigger" border="bottom" style={{ maxWidth: CALLOUT_WIDTH }}>
+				<p>
+					The
+					{' '}
+					<code>"pointerenter"</code>
+					{' '}
+					trigger will open the tooltip on
+					{' '}
+					<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerenter_event" target="_blank" rel="noopener noreferrer">pointerenter</a>
+					.
+					This occurs whenever a pointer (mouse or touch)
+					enters the bounding box of the reference.
+					It will close on
+					{' '}
+					<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerleave_event" target="_blank" rel="noopener noreferrer">pointerleave</a>
+					{' '}
+					(whenever a pointer leaves the bounding box) or
+					{' '}
+					<kbd>Escape</kbd>
+					.
+				</p>
+				<p>
+					Note that the
+					{' '}
+					<code>"mouseenter"</code>
+					{' '}
+					event is treated as an alias for
+					{' '}
+					<code>"pointerenter"</code>
+					.
+				</p>
+			</Callout>
+			<Button variant="solid" ref={setReference}>
+				Reference
+			</Button>
+			<Tooltip
+				reference={reference}
+				trigger="pointerenter"
+				placement={select('Placement', placements, defaultPlacement)}
+				hideDelay={number('Hide delay', defaultDelay)}
+			>
+				Tooltip
+			</Tooltip>
+		</>
+	);
+};
+
+export const FocusTrigger = (): JSX.Element => {
+	const [reference, setReference] = React.useState<HTMLButtonElement | null>(null);
+
+	return (
+		<>
+			<Callout title="Focus trigger" border="bottom" style={{ maxWidth: CALLOUT_WIDTH }}>
+				The
+				{' '}
+				<code>"focus"</code>
+				{' '}
+				trigger will open the tooltip on
+				{' '}
+				<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event" target="_blank" rel="noopener noreferrer">focus</a>
+				{' '}
+				and close it on
+				{' '}
+				<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event" target="_blank" rel="noopener noreferrer">blur</a>
+				{' '}
+				or
+				{' '}
+				<kbd>Escape</kbd>
+				.
+			</Callout>
+			<Button variant="solid" ref={setReference}>
+				Reference
+			</Button>
+			<Tooltip
+				reference={reference}
+				trigger="focus"
+				placement={select('Placement', placements, defaultPlacement)}
+			>
+				Tooltip
+			</Tooltip>
+		</>
+	);
+};
+
+export const ClickTrigger = (): JSX.Element => {
+	const [reference, setReference] = React.useState<HTMLButtonElement | null>(null);
+
+	return (
+		<>
+			<Callout title="Click trigger" border="bottom" style={{ maxWidth: CALLOUT_WIDTH }}>
+				The
+				{' '}
+				<code>"click"</code>
+				{' '}
+				trigger will toggle on pointer
+				{' '}
+				<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event" target="_blank" rel="noopener noreferrer">click</a>
+				{' '}
+				or keyboard clicks, which are either
+				{' '}
+				<code>keyup</code>
+				{' '}
+				<kbd>Space</kbd>
+				{' '}
+				or
+				{' '}
+				<code>keydown</code>
+				{' '}
+				<kbd>Enter</kbd>
+				{' '}
+				, and will close on external click or
+				{' '}
+				<kbd>Escape</kbd>
+				.
+			</Callout>
+			<Button variant="solid" ref={setReference}>
+				Reference
+			</Button>
+			<Tooltip
+				reference={reference}
+				trigger="click"
+				placement={select('Placement', placements, defaultPlacement)}
+			>
+				Tooltip
+			</Tooltip>
+		</>
+	);
+};
+
+export const ManualTrigger = (): JSX.Element => {
+	const [reference, setReference] = React.useState<HTMLButtonElement | null>(null);
+	const [isOpen, setOpen] = React.useState(false);
+
+	return (
+		<>
+			<Callout title="Manual trigger" border="bottom" style={{ maxWidth: CALLOUT_WIDTH }}>
+				The
+				{' '}
+				<code>"manual"</code>
+				{' '}
+				allows you to fully control how the tooltip opens and closes.
+				Only use this trigger if you need to control state external to the
+				tooltip, but be careful to ensure that it can be opened and closed by everyone.
+			</Callout>
+			<Button variant="solid" ref={setReference} onClick={() => setOpen(!isOpen)}>
+				Reference
+			</Button>
+			<Tooltip
+				reference={reference}
+				trigger="manual"
+				isOpen={isOpen}
+				placement={select('Placement', placements, defaultPlacement)}
+			>
+				Tooltip
+			</Tooltip>
+		</>
+	);
+};
+
+export const CustomReference: React.FunctionComponent = () => {
 	const [ref, setRef] = React.useState<HTMLSpanElement | null>();
 	return (
 		<>
@@ -34,32 +275,12 @@ export const CustomTriggers: React.FunctionComponent = () => {
 			</p>
 			<Tooltip
 				reference={ref}
-				placement={select('Placement', placements, 'top')}
 				trigger='click pointerenter'
+				placement={select('Placement', placements, 'bottom-start')}
+				hideDelay={number('Hide delay', defaultDelay)}
 			>
 				Lorem ipsum is a placeholder text commonly used to demonstrate
 				the visual form of a document or a typeface without relying on meaningful content.
-			</Tooltip>
-		</>
-	);
-};
-
-export const Controlled: React.FunctionComponent = () => {
-	const [ref, setRef] = React.useState<HTMLButtonElement | null>();
-	const [isOpen, setOpen] = React.useState(false);
-	const toggle = (): void => setOpen(!isOpen);
-
-	return (
-		<>
-			<Button variant="solid" ref={setRef} onClick={toggle}>Show tooltip</Button>
-			<Tooltip
-				reference={ref}
-				placement={select('Placement', placements, 'top')}
-				trigger='manual'
-				isOpen={isOpen}
-			>
-				This tooltip is triggered manually and can only be opened/closed
-				by clicking its reference button.
 			</Tooltip>
 		</>
 	);

--- a/packages/react/src/components/Tooltip/index.test.tsx
+++ b/packages/react/src/components/Tooltip/index.test.tsx
@@ -18,76 +18,76 @@ const TooltipFixture: React.FunctionComponent<TooltipProps> = ({
 }: TooltipProps) => {
 	const [ref, setRef] = React.useState<HTMLSpanElement | null>();
 	return (
-		<>
+		<div data-testid="test">
 			<p>
 				<span role="button" tabIndex={0} ref={setRef}>Lorem ipsum</span>
 				{' '}
 				dolor sit amet consectetur adipisicing elit.
 			</p>
 			<Tooltip reference={ref} trigger={trigger} asLabel={asLabel}>{ children }</Tooltip>
-		</>
+		</div>
 	);
 };
 
 test('a tooltip is rendered when `isOpen`', (t) => {
 	render(<Tooltip isOpen>{ defaultContents }</Tooltip>);
-	t.is(screen.getByRole('tooltip', { hidden: true }).textContent, defaultContents);
+	t.truthy(screen.queryByRole('tooltip', { hidden: true }));
+	t.is(screen.queryByRole('tooltip', { hidden: true }).textContent, defaultContents);
 });
 
-test('the click trigger toggles the tooltip\'s visibility on click', (t) => {
+test('the click trigger toggles the tooltip\'s visibility on click', async (t) => {
 	render(<TooltipFixture trigger="click" />);
-	t.falsy(screen.queryByText(defaultContents));
-	const ref = screen.getByRole('button');
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
+	const ref = screen.queryByRole('button');
 
 	fireEvent.focus(ref);
-	t.falsy(screen.queryByText(defaultContents));
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
 
 	fireEvent.pointerEnter(ref);
-	t.falsy(screen.queryByText(defaultContents));
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
 
 	fireEvent.click(ref);
-	t.truthy(screen.queryByText(defaultContents));
+	t.truthy(screen.queryByRole('tooltip', { hidden: true }));
 });
 
 test('the focus trigger toggles the tooltip\'s visibility on focus', (t) => {
 	render(<TooltipFixture trigger="focus" />);
-	t.falsy(screen.queryByText(defaultContents));
-	const ref = screen.getByRole('button');
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
+	const ref = screen.queryByRole('button');
 
 	fireEvent.pointerEnter(ref);
-	t.falsy(screen.queryByText(defaultContents));
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
 
 	// in the real world, clicking also triggers focus but it doesn't here
 	fireEvent.click(ref);
-	t.falsy(screen.queryByText(defaultContents));
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
 
 	fireEvent.focus(ref);
-	t.truthy(screen.queryByText(defaultContents));
+	t.truthy(screen.queryByRole('tooltip', { hidden: true }));
 });
 
 test('the mouseenter trigger toggles the tooltip\'s visibility on pointer enter', (t) => {
 	render(<TooltipFixture trigger="mouseenter" />);
-	t.falsy(screen.queryByText(defaultContents));
-	const ref = screen.getByRole('button');
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
+	const ref = screen.queryByRole('button');
 
 	fireEvent.focus(ref);
-	t.falsy(screen.queryByText(defaultContents));
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
 
 	fireEvent.click(ref);
-	t.falsy(screen.queryByText(defaultContents));
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
 
 	fireEvent.pointerEnter(ref);
-	t.truthy(screen.queryByText(defaultContents));
+	t.truthy(screen.queryByRole('tooltip', { hidden: true }));
 });
 
 test('tooltip contents label the reference even when the tooltip isn\'t visible', (t) => {
 	render(<TooltipFixture trigger="focus pointerenter" asLabel />);
 	t.truthy(screen.queryByRole('button', { name: defaultContents }));
-	t.is(screen.getByRole('button').getAttribute('aria-label'), defaultContents);
 });
 
 test('complex tooltip contents are flattened and used as the reference\'s label even when the tooltip isn\'t visible', (t) => {
-	const FLATTENED = 'lorem ipsum dolor sit amet consectetur adipisicing elit!1';
+	const FLATTENED = 'lorem ipsum dolor sit amet consectetur adipisicing elit !1';
 	render((
 		<TooltipFixture trigger="focus pointerenter" asLabel>
 			<p>
@@ -110,5 +110,4 @@ test('complex tooltip contents are flattened and used as the reference\'s label 
 		</TooltipFixture>
 	));
 	t.truthy(screen.queryByRole('button', { name: FLATTENED }));
-	t.is(screen.getByRole('button').getAttribute('aria-label'), FLATTENED);
 });

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -103,14 +103,10 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((
 	 */
 	React.useEffect(() => {
 		if (reference && reference instanceof Element) {
-			if (asLabel) {
-				reference.setAttribute('aria-labelledby', ariaId);
-			} else {
-				// aria-describedby can point to more than one id
-				const idArray = (reference.getAttribute('aria-describedby') || ariaId).split(/\s+/g);
-				if (!idArray.includes(ariaId)) idArray.push(ariaId);
-				reference.setAttribute('aria-describedby', idArray.join(' '));
-			}
+			reference.setAttribute(
+				(asLabel) ? 'aria-labelledby' : 'aria-describedby',
+				ariaId,
+			);
 		}
 	}, [asLabel, reference, ariaId]);
 

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useColorScheme';
 export * from './useConfig';
+export * from './useExternalClick';
 export * from './useForwardRef';
 export * from './usePopper';
 export * from './usePopperTriggers';

--- a/packages/react/src/hooks/useExternalClick.ts
+++ b/packages/react/src/hooks/useExternalClick.ts
@@ -1,0 +1,44 @@
+import { useEffect, useMemo } from 'react';
+
+interface ExternalClickProps {
+	/**
+	 * The event target or targets that should not trigger the callback when clicked.
+	 * Only valid [EventTargets](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+	 * will be used.
+	 */
+	externalTo?: EventTarget | EventTarget[];
+	/**
+	 * A callback function that triggers when something other than the first
+	 * parameter is clicked.
+	 */
+	onExternalClick?: () => void;
+}
+
+/**
+ * A hook that triggers a callback function when something other than the specified
+ * target(s) are clicked.
+ */
+export const useExternalClick = ({ externalTo, onExternalClick }: ExternalClickProps): void => {
+	const excluded = useMemo(() => {
+		if (Array.isArray(externalTo)) return externalTo;
+		return [externalTo];
+	}, [externalTo]);
+
+	if (!externalTo) return;
+
+	useEffect(() => {
+		const documentClickHandler = (e: MouseEvent): void => {
+			const clickPath = e.composedPath();
+			if (excluded.some((el) => el && clickPath.includes(el))) return;
+			if (onExternalClick) onExternalClick();
+		};
+
+		if (excluded.length) {
+			document.addEventListener('click', documentClickHandler);
+		}
+
+		return () => {
+			document.removeEventListener('click', documentClickHandler);
+		};
+	}, [excluded, onExternalClick]);
+};

--- a/packages/react/src/hooks/usePopperTriggers.ts
+++ b/packages/react/src/hooks/usePopperTriggers.ts
@@ -1,163 +1,236 @@
-import { useLayoutEffect, useRef, useState } from 'react';
-import { VirtualElement } from '@popperjs/core';
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo, useRef,
+} from 'react';
+import { useExternalClick } from './useExternalClick';
+import { PopperCoreProps } from '../types/popper';
+import { canUseDOM } from '../config';
 
-/**
- * Control a popper's open state with a list of triggers. The returned value
- * should be used to control the `isOpen` state of a Popper component.
- */
-export const usePopperTriggers = ({
-	reference, popper, trigger, isOpen, hideDelay,
-}: {
-	/** The reference element that the popper will be attached to. */
-	reference?: Element | VirtualElement | null;
-	/** The popper element. */
-	popper?: HTMLElement | null;
+type PopperTriggersOpen = 'click.reference' | 'focus' | 'focusin' | 'pointerenter';
+type PopperTriggersClose = 'click.reference' | 'click.internal' | 'click.external' | 'escape' | 'blur' | 'pointerleave';
+export interface UsePopperTriggersProps extends PopperCoreProps {
+	/** Indicates whether the popper is open or closed. */
+	isOpen?: boolean;
 	/**
 	 * A space-separated string of events. Triggers can be any combination of the
 	 * following:
-	 * * `click`
-	 * * `focus`
-	 * * `focusin`
-	 * * `mouseenter`
-	 * * `pointerenter`
-	 * * `manual` - this will override all other triggers, giving you full
-	 * control over visibility.
+	 * - `click`
+	 * - `focus`
+	 * - `focusin`
+	 * - `mouseenter`
+	 * - `pointerenter`
 	 */
 	trigger: string;
 	/**
-	 * Indicates the initial open state (whether the popper should be displayed
-	 * or not on first render). `trigger` events will control the open state
-	 * after first render.
-	 */
-	isOpen: boolean;
-	/**
-	 * The duration in milliseconds that should elapse before the popper
-	 * disappears after moving the cursor off of the reference element. Only has
-	 * an effect for the `mouseenter` or `pointerenter` triggers.
+	 * The duration in milliseconds that should elapse before closing, beginning
+	 * after the pointer exits the reference's bounding box. Only has an effect
+	 * for the `mouseenter` or `pointerenter` triggers.
 	 */
 	hideDelay?: number;
-}): boolean => {
-	if (trigger.includes('manual')) return isOpen;
-	const [open, setOpen] = useState(isOpen);
-	const [openTrigger, setOpenTrigger] = useState<string>();
+	/**
+	 * A callback that occurs when the popper wants to open. The reason it is
+	 * making this request is given by the first parameter.
+	 * - `"click.reference"` - the reference element was clicked.
+	 * - `"focus"` - the reference was focused.
+	 * See [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+	 * - `"focusin"` - the reference is about to be focused.
+	 * See [focusin event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusin_event).
+	 * - `"pointerenter"` - a pointer (mouse or touch) entered the bounding box of the reference.
+	 * See [pointerenter event](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerenter_event).
+	 */
+	onRequestOpen?: (
+		/** Why the popper wants to open. */
+		triggeredBy: PopperTriggersOpen,
+	) => void;
+	/**
+	 * A callback that occurs when the popper wants to close. The reason it is
+	 * making this request is given by the first parameter.
+	 * - `"click.reference"` - the reference element was clicked.
+	 * - `"click.internal"` - something inside the popper was clicked.
+	 * - `"click.external"` - something outside the popper or reference was clicked.
+	 * - `"escape"` - the Escape key was pressed.
+	 * - `"blur"` - the reference element lost focus.
+	 * See [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+	 * - `"pointerleave"` - a pointer (mouse or touch) left the bounding box of the reference.
+	 * See [pointerenter event](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerenter_event).
+	 */
+	onRequestClose?: (
+		/** Why the popper wants to close. */
+		triggeredBy: PopperTriggersClose,
+	) => void;
+}
+
+/**
+ * Use Popper.js triggers to trigger requests to open or close.
+ */
+export const usePopperTriggers = ({
+	reference,
+	popper,
+	trigger,
+	isOpen,
+	hideDelay,
+	onRequestOpen,
+	onRequestClose,
+}: UsePopperTriggersProps): void => {
+	const openTrigger = useRef<PopperTriggersOpen>();
+	const keyboardClick = useRef(false);
+	const spaceClick = useRef(false);
 	const timer = useRef<number>();
 
 	const clearTimer = (): void => window.clearTimeout(timer.current);
 
-	const show = ({ type }: Event): void => {
-		if (!open) setOpenTrigger(type);
-		setOpen(true);
+	const show = useCallback((triggeredBy: PopperTriggersOpen) => {
+		openTrigger.current = triggeredBy;
+		if (onRequestOpen) onRequestOpen(triggeredBy);
 		clearTimer();
+	}, [onRequestOpen]);
+
+	const hide = useCallback((triggeredBy: PopperTriggersClose) => {
+		if (onRequestClose) onRequestClose(triggeredBy);
+	}, [onRequestClose]);
+
+	const externalTo = useMemo(() => {
+		if (canUseDOM) {
+			return [popper, reference].reduce<EventTarget[]>((t, el) => {
+				if (el instanceof EventTarget) t.push(el);
+				return t;
+			}, []);
+		}
+		return undefined;
+	}, [popper, reference]);
+
+	const onExternalClick = () => {
+		if (popper && trigger.includes('click')) return hide('click.external');
+		return undefined;
 	};
 
-	const hide = (): void => setOpen(false);
-
-	const toggle = (e: Event): void => {
-		if (open) hide();
-		else show(e);
-	};
-
-	const delayedHide = (): void => {
-		timer.current = window.setTimeout((): void => {
-			if (openTrigger === 'pointerenter') hide();
-		}, hideDelay);
-	};
-
-	// click handlers
-	const docKeydownHandler = (e: KeyboardEvent): void => {
-		if (e.key === 'Escape') hide();
-	};
-	const docClickHandler = (e: MouseEvent): void => {
-		const clickPath = e.composedPath();
-		const tooltipClick = clickPath.some((el) => {
-			if (el instanceof Element) {
-				return el.getAttribute('role') === 'popper';
-			}
-			return false;
-		});
-		const referenceClick = (): boolean => {
-			if (reference && reference instanceof Element) {
-				return clickPath.includes(reference);
-			}
-			return false;
-		};
-		if (tooltipClick || referenceClick()) return;
-		hide();
-	};
-	const keydownHandler = (e: KeyboardEvent): void => {
-		if (e.key === 'Enter') toggle(e);
-		if (e.key === ' ') e.preventDefault();
-	};
-	const keyupHandler = (e: KeyboardEvent): void => {
-		if (e.key === ' ') toggle(e);
-	};
+	// hide on external clicks, but don't focus the reference since whatever was
+	// clicked should receive focus
+	useExternalClick({
+		externalTo,
+		onExternalClick,
+	});
 
 	useLayoutEffect(() => {
-		if (reference && (reference instanceof HTMLElement || reference instanceof window.SVGElement)) {
-			// hide on Escape for all triggers
-			document.addEventListener('keydown', docKeydownHandler);
+		const toggle = (): void => {
+			if (isOpen) hide('click.reference');
+			else show('click.reference');
+		};
 
-			// click
-			if (trigger.includes('click')) {
-				reference.addEventListener('click', toggle);
-				reference.addEventListener('keydown', keydownHandler as EventListener);
-				reference.addEventListener('keyup', keyupHandler as EventListener);
-				document.addEventListener('click', docClickHandler);
+		// keyboard
+		const docKeydownHandler = (e: KeyboardEvent): void => {
+			if (e.key === 'Escape') hide('escape');
+		};
+		const keydownHandler = (e: KeyboardEvent): void => {
+			if (e.key === 'Enter') {
+				keyboardClick.current = true;
+				toggle();
 			}
+			if (e.key === ' ') {
+				spaceClick.current = true;
+				e.preventDefault();
+			}
+		};
+		const keyupHandler = (e: KeyboardEvent): void => {
+			if (e.key === ' ' && spaceClick.current) {
+				keyboardClick.current = true;
+				spaceClick.current = false;
+				toggle();
+			}
+		};
 
+		// click
+		const clickHandler = (): void => {
+			if (keyboardClick.current) {
+				keyboardClick.current = false;
+				return;
+			}
+			toggle();
+		};
+
+		// focus
+		const focusHandler = () => show('focus');
+		const focusinHandler = () => show('focusin');
+		const blurHandler = () => hide('blur');
+
+		// hover
+		const pointerenterHandler = () => show('pointerenter');
+		const pointerleaveHandler = () => {
+			timer.current = window.setTimeout((): void => {
+				if (openTrigger.current === 'pointerenter') hide('pointerleave');
+			}, hideDelay);
+		};
+
+		const isElement = (el: typeof reference): el is Element => (
+			(el) ? el instanceof Element : false
+		);
+		const isHTMLElement = (el: typeof reference): el is HTMLElement => (
+			(el) ? el instanceof HTMLElement : false
+		);
+
+		// hide on Escape for all triggers
+		document.addEventListener('keydown', docKeydownHandler);
+
+		// click
+		if (trigger.includes('click') && isHTMLElement(reference)) {
+			reference.addEventListener('click', clickHandler);
+			reference.addEventListener('keydown', keydownHandler);
+			reference.addEventListener('keyup', keyupHandler);
+		}
+
+		if (isElement(reference)) {
 			// focus & focusin
 			if (trigger.includes('focus')) {
-				reference.addEventListener('focus', show);
+				reference.addEventListener('focus', focusHandler);
 			}
 			if (trigger.includes('focusin')) {
-				reference.addEventListener('focusin', show);
+				reference.addEventListener('focusin', focusinHandler);
 			}
 			if (trigger.includes('focus') || trigger.includes('focusin')) {
-				reference.addEventListener('blur', hide);
+				reference.addEventListener('blur', blurHandler);
 			}
 
 			// mouseenter & pointerenter
 			if (trigger.includes('mouseenter') || trigger.includes('pointerenter')) {
-				reference.addEventListener('pointerenter', show);
-				reference.addEventListener('pointerleave', delayedHide);
+				reference.addEventListener('pointerenter', pointerenterHandler);
+				reference.addEventListener('pointerleave', pointerleaveHandler);
 				if (popper) {
-					popper.addEventListener('pointerleave', delayedHide);
+					popper.addEventListener('pointerleave', pointerleaveHandler);
 				}
 			}
+		}
 
-			if (popper) {
-				popper.addEventListener('pointerenter', clearTimer);
-			}
+		if (popper) {
+			popper.addEventListener('pointerenter', clearTimer);
 		}
 
 		return (): void => {
 			clearTimer();
-			if (reference && (
-				reference instanceof HTMLElement || reference instanceof window.SVGElement
-			)) {
-				// click
-				reference.removeEventListener('click', toggle);
-				reference.removeEventListener('keydown', keydownHandler as EventListener);
-				reference.removeEventListener('keyup', keyupHandler as EventListener);
-				document.removeEventListener('click', docClickHandler);
-				document.removeEventListener('keydown', docKeydownHandler);
+			document.removeEventListener('keydown', docKeydownHandler);
 
+			if (isHTMLElement(reference)) {
+				// click
+				reference.removeEventListener('click', clickHandler);
+				reference.removeEventListener('keydown', keydownHandler);
+				reference.removeEventListener('keyup', keyupHandler);
+			}
+
+			if (isElement(reference)) {
 				// focus & focusin
-				reference.removeEventListener('focus', show);
-				reference.removeEventListener('focusin', show);
-				reference.removeEventListener('blur', hide);
+				reference.removeEventListener('focus', focusHandler);
+				reference.removeEventListener('focusin', focusinHandler);
+				reference.removeEventListener('blur', blurHandler);
 
 				// mouseenter & pointerenter
-				reference.removeEventListener('pointerenter', show);
-				reference.removeEventListener('pointerleave', delayedHide);
+				reference.removeEventListener('pointerenter', pointerenterHandler);
+				reference.removeEventListener('pointerleave', pointerleaveHandler);
+			}
 
-				if (popper) {
-					popper.removeEventListener('pointerenter', clearTimer);
-					popper.removeEventListener('pointerleave', delayedHide);
-				}
+			if (popper) {
+				popper.removeEventListener('pointerenter', clearTimer);
+				popper.removeEventListener('pointerleave', pointerleaveHandler);
 			}
 		};
-	}, [reference, popper, trigger]);
-
-	return open;
+	}, [reference, popper, trigger, show, hide, hideDelay, isOpen]);
 };

--- a/packages/react/src/hooks/usePopperTriggers.ts
+++ b/packages/react/src/hooks/usePopperTriggers.ts
@@ -152,7 +152,10 @@ export const usePopperTriggers = ({
 		// focus
 		const focusHandler = () => show('focus');
 		const focusinHandler = () => show('focusin');
-		const blurHandler = () => hide('blur');
+		const blurHandler = () => {
+			spaceClick.current = false;
+			hide('blur');
+		};
 
 		// hover
 		const pointerenterHandler = () => show('pointerenter');

--- a/packages/react/src/hooks/useToken.ts
+++ b/packages/react/src/hooks/useToken.ts
@@ -38,9 +38,9 @@ export const useToken = ({
 	name,
 	value,
 	el = document.documentElement,
-}: UseTokenProps): [UseTokenProps['value'], Dispatch<SetStateAction<UseTokenProps['value']>>] => {
+}: UseTokenProps): [string | number | null, Dispatch<SetStateAction<string | number | null>>] => {
 	const prefixedName = useMemo(() => prefix(name), [name]);
-	const [token, setToken] = useState(value);
+	const [token, setToken] = useState(value || null);
 
 	// read the value from the element
 	useEffect(() => {

--- a/packages/react/src/hooks/useToken.ts
+++ b/packages/react/src/hooks/useToken.ts
@@ -1,5 +1,6 @@
 import {
-	useEffect, useMemo, useState,
+	useEffect, useLayoutEffect, useMemo, useState,
+	Dispatch, SetStateAction,
 } from 'react';
 import { prefix, canUseDOM } from '../config';
 
@@ -20,12 +21,7 @@ const setVar = (
 	el.style.setProperty(`--${varName}`, value.toString());
 };
 
-/** Use a design token. Gets and sets the token as a CSS custom property. */
-export const useToken = ({
-	name,
-	value,
-	el = document.documentElement,
-}: {
+export interface UseTokenProps {
 	/** The token's name. Note that this shouldn't begin with `--`. */
 	name: string;
 	/**
@@ -34,24 +30,28 @@ export const useToken = ({
 	 */
 	value?: string | number | null;
 	/** The element where the CSS custom property should be stored/retrieved. */
-	el: HTMLElement | null;
-}): [string | number | null, React.Dispatch<React.SetStateAction<string | number | null>>] => {
+	el?: HTMLElement | null;
+}
+
+/** Use a design token. Gets or sets the token as a CSS custom property. */
+export const useToken = ({
+	name,
+	value,
+	el = document.documentElement,
+}: UseTokenProps): [UseTokenProps['value'], Dispatch<SetStateAction<UseTokenProps['value']>>] => {
 	const prefixedName = useMemo(() => prefix(name), [name]);
-	const [token, setToken] = useState(value || getVar(prefixedName, el));
+	const [token, setToken] = useState(value);
 
+	// read the value from the element
 	useEffect(() => {
-		if (el) {
-			setToken(
-				(typeof value === 'undefined') ? getVar(prefixedName, el) : value,
-			);
-		}
-	}, [el, value]);
+		const val = getVar(prefixedName, el);
+		if (val) setToken(val);
+	}, [prefixedName, el]);
 
-	useEffect(() => {
-		if (el && token) {
-			setVar(prefixedName, token, el);
-		}
-	}, [el, token, prefixedName]);
+	// set the value on the element
+	useLayoutEffect(() => {
+		if (value) setVar(prefixedName, value, el);
+	}, [value, prefixedName, el]);
 
 	return [token, setToken];
 };

--- a/packages/react/src/types/popper.ts
+++ b/packages/react/src/types/popper.ts
@@ -1,6 +1,6 @@
-import { Options } from '@popperjs/core';
+import { Options, VirtualElement } from '@popperjs/core';
 
-export { Placement, Modifier, VirtualElement } from '@popperjs/core';
+export * from '@popperjs/core';
 
 export interface PopperOptions {
 	/** The [Popper.js placement option](https://popper.js.org/docs/v2/constructors/#placement). */
@@ -11,4 +11,19 @@ export interface PopperOptions {
 	strategy: Options['strategy'];
 	/** The [Popper.js onFirstUpdate option](https://popper.js.org/docs/v2/constructors/#onFirstUpdate). */
 	onFirstUpdate?: Options['onFirstUpdate'];
+}
+
+export interface PopperCoreProps {
+	/**
+	 * The reference element that the popper will be attached to.
+	 *
+	 * [Popper.js - `createPopper`](https://popper.js.org/docs/v2/constructors/#createpopper)
+	 */
+	reference?: Element | VirtualElement | null;
+	/**
+	 * The popper element, which will be attached to the reference element.
+	 *
+	 * [Popper.js - `createPopper`](https://popper.js.org/docs/v2/constructors/#createpopper)
+	 */
+	popper?: HTMLElement | null;
 }


### PR DESCRIPTION
This streamlines some of our Popper.js handling, and changes some of the internals of Tooltip & Popover to make them more distinct.

- Tooltip uses a persistent hidden div to name/describe the referenced element. The actual tooltip chat bubble is purely a visual affordance now.
- Popover must be controlled by responding to requests to open/close, and now includes callbacks `onOpen` and `onClose`.
- A new external click hook has been added.