### PR TITLE
Tooltip styling improvements

### DIFF
--- a/packages/core/src/color/tokens.scss
+++ b/packages/core/src/color/tokens.scss
@@ -190,10 +190,12 @@ $system-colors: (
 
 /// The main background color.
 $background-color: var(--nds-white) !default;
+/// The inverse background color.
+$background-color-inverse: var(--nds-base-color-90) !default;
 /// The main text color.
 $text-color: var(--nds-base-color-90) !default;
 /// The inverse text color.
-$text-color-inverse: var(--nds-background-color) !default;
+$text-color-inverse: var(--nds-white) !default;
 /// A subdued or "muted" text color, used for less emphasized text.
 $subdued-color: var(--nds-base-color-60) !default;
 /// The background color for the `::selection` state.
@@ -213,6 +215,7 @@ $focus-halo-outer-color: var(--nds-focus-color) !default;
 
 $-scheme-light-default: (
 	--nds-background-color: #{$background-color},
+	--nds-background-color-inverse: #{$background-color-inverse},
 	--nds-text-color: #{$text-color},
 	--nds-text-color-inverse: #{$text-color-inverse},
 	--nds-subdued-color: #{$subdued-color},
@@ -236,6 +239,9 @@ $scheme-light: map.merge($-scheme-light-default, $scheme-light);
 
 $-scheme-dark-default: (
 	--nds-background-color: var(--nds-base-color-10),
+	--nds-background-color-inverse: #{$background-color},
+	--nds-text-color: #{$background-color},
+	--nds-text-color-inverse: var(--nds-base-color-10),
 	--nds-focus-color-background: var(--nds-blue-90),
 	--nds-primary-color: color.family('primary-color', color.$primary-family, color.$primary-grade, true),
 	--nds-base-color: color.family('base-color', color.$base-family, color.$base-grade, true),

--- a/packages/core/src/common/popper.scss
+++ b/packages/core/src/common/popper.scss
@@ -1,0 +1,102 @@
+/// A triangle arrow that connects with a Popper.js element
+@mixin arrow (
+	$size: 12px,
+	$border-width: 1px,
+	$background-color: var(--nds-background-color),
+) {
+	$arrow-border-width: calc(#{$size} / 2);
+
+	position: absolute;
+	width: $size;
+	height: $size;
+	border-color: inherit;
+
+	&::before {
+		position: absolute;
+		content: '';
+		border-color: transparent;
+		border-style: solid;
+	}
+
+	&::after {
+		position: absolute;
+		z-index: -1;
+		content: '';
+		border-color: transparent;
+		border-style: solid;
+	}
+
+	[data-popper-placement^='top'] > & {
+		bottom: 0;
+
+		&::before {
+			bottom: calc(-1 * #{$arrow-border-width} + #{$border-width});
+			left: 0;
+			border-width: $arrow-border-width $arrow-border-width 0;
+			border-top-color: $background-color;
+			transform-origin: center top;
+		}
+
+		&::after {
+			bottom: calc(-1 * #{$arrow-border-width});
+			left: 0;
+			border-width: $arrow-border-width $arrow-border-width 0;
+			border-top-color: inherit;
+		}
+	}
+
+	[data-popper-placement^='right'] > & {
+		left: 0;
+
+		&::before {
+			left: calc(-1 * #{$arrow-border-width} + #{$border-width});
+			border-width: $arrow-border-width $arrow-border-width $arrow-border-width 0;
+			border-right-color: $background-color;
+			transform-origin: center right;
+		}
+
+		&::after {
+			top: 0;
+			left: calc(-1 * #{$arrow-border-width});
+			border-width: $arrow-border-width $arrow-border-width $arrow-border-width 0;
+			border-right-color: inherit;
+		}
+	}
+
+	[data-popper-placement^='bottom'] > & {
+		top: 0;
+
+		&::before {
+			top: calc(-1 * #{$arrow-border-width} + #{$border-width});
+			left: 0;
+			border-width: 0 $arrow-border-width $arrow-border-width;
+			border-bottom-color: $background-color;
+			transform-origin: center bottom;
+		}
+
+		&::after {
+			top: calc(-1 * #{$arrow-border-width});
+			left: 0;
+			border-width: 0 $arrow-border-width $arrow-border-width;
+			border-bottom-color: inherit;
+		}
+	}
+
+	[data-popper-placement^='left'] > & {
+		right: 0;
+
+		&::before {
+			right: calc(-1 * #{$arrow-border-width} + #{$border-width});
+			border-width: $arrow-border-width 0 $arrow-border-width $arrow-border-width;
+			border-left-color: $background-color;
+			transform-origin: center left;
+		}
+
+		&::after {
+			top: 0;
+			right: calc(-1 * #{$arrow-border-width});
+			border-width: $arrow-border-width 0 $arrow-border-width $arrow-border-width;
+			border-left-color: inherit;
+		}
+	}
+}

--- a/packages/core/src/components/popover/index.scss
+++ b/packages/core/src/components/popover/index.scss
@@ -1,5 +1,6 @@
 @forward 'tokens';
 @use 'tokens';
+@use '../../common/popper';
 @use '../../config';
 @use '../../spacing';
 @use '../../type';
@@ -9,7 +10,6 @@
 @mixin base {
 	--nds-popover-border-width: #{tokens.$border-width};
 	--nds-popover-arrow-size: #{tokens.$arrow-size};
-	--nds-popover-arrow-border: #{tokens.$arrow-border};
 	--nds-popover-offset-y: #{tokens.$offset-y};
 	--nds-popover-max-width: #{tokens.$max-width};
 	--nds-popover-padding-x: #{tokens.$padding-x};
@@ -112,102 +112,6 @@
 	}
 }
 
-@mixin arrow {
-	position: absolute;
-	width: var(--nds-popover-arrow-size);
-	height: var(--nds-popover-arrow-size);
-	border-color: inherit;
-
-	&::before {
-		position: absolute;
-		content: '';
-		border-color: transparent;
-		border-style: solid;
-	}
-
-	&::after {
-		position: absolute;
-		z-index: -1;
-		content: '';
-		border-color: transparent;
-		border-style: solid;
-	}
-}
-
-@mixin placement-top-arrow {
-	bottom: 0;
-
-	&::before {
-		bottom: calc(-1 * var(--nds-popover-arrow-border) + var(--nds-popover-border-width));
-		left: 0;
-		border-width: var(--nds-popover-arrow-border) var(--nds-popover-arrow-border) 0;
-		border-top-color: var(--nds-background-color);
-		transform-origin: center top;
-	}
-
-	&::after {
-		bottom: calc(-1 * var(--nds-popover-arrow-border));
-		left: 0;
-		border-width: var(--nds-popover-arrow-border) var(--nds-popover-arrow-border) 0;
-		border-top-color: inherit;
-	}
-}
-
-@mixin placement-right-arrow {
-	left: 0;
-
-	&::before {
-		left: calc(-1 * var(--nds-popover-arrow-border) + var(--nds-popover-border-width));
-		border-width: var(--nds-popover-arrow-border) var(--nds-popover-arrow-border) var(--nds-popover-arrow-border) 0;
-		border-right-color: var(--nds-background-color);
-		transform-origin: center right;
-	}
-
-	&::after {
-		top: 0;
-		left: calc(-1 * var(--nds-popover-arrow-border));
-		border-width: var(--nds-popover-arrow-border) var(--nds-popover-arrow-border) var(--nds-popover-arrow-border) 0;
-		border-right-color: inherit;
-	}
-}
-
-@mixin placement-bottom-arrow {
-	top: 0;
-
-	&::before {
-		top: calc(-1 * var(--nds-popover-arrow-border) + var(--nds-popover-border-width));
-		left: 0;
-		border-width: 0 var(--nds-popover-arrow-border) var(--nds-popover-arrow-border);
-		border-bottom-color: var(--nds-background-color);
-		transform-origin: center bottom;
-	}
-
-	&::after {
-		top: calc(-1 * var(--nds-popover-arrow-border));
-		left: 0;
-		border-width: 0 var(--nds-popover-arrow-border) var(--nds-popover-arrow-border);
-		border-bottom-color: inherit;
-	}
-}
-
-@mixin placement-left-arrow {
-	right: 0;
-
-	&::before {
-		right: calc(-1 * var(--nds-popover-arrow-border) + var(--nds-popover-border-width));
-		border-width: var(--nds-popover-arrow-border) 0 var(--nds-popover-arrow-border) var(--nds-popover-arrow-border);
-		border-left-color: var(--nds-background-color);
-		transform-origin: center left;
-	}
-
-	&::after {
-		top: 0;
-		right: calc(-1 * var(--nds-popover-arrow-border));
-		border-width: var(--nds-popover-arrow-border) 0 var(--nds-popover-arrow-border) var(--nds-popover-arrow-border);
-		border-left-color: inherit;
-	}
-}
-
 @mixin actionbar {
 	display: flex;
 	padding: calc(var(--nds-popover-padding-y) / 2) var(--nds-popover-padding-x);
@@ -241,28 +145,15 @@
 			@include close-button;
 		}
 
-		.nds-popover__arrow {
-			@include arrow;
-		}
-
-		.nds-popover[data-popper-placement^='top'] > .nds-popover__arrow {
-			@include placement-top-arrow;
-		}
-
-		.nds-popover[data-popper-placement^='right'] > .nds-popover__arrow {
-			@include placement-right-arrow;
-		}
-
-		.nds-popover[data-popper-placement^='bottom'] > .nds-popover__arrow {
-			@include placement-bottom-arrow;
-		}
-
-		.nds-popover[data-popper-placement^='left'] > .nds-popover__arrow {
-			@include placement-left-arrow;
-		}
-
 		.nds-popover__actions {
 			@include actionbar;
+		}
+
+		.nds-popover__arrow {
+			@include popper.arrow(
+				$size: var(--nds-popover-arrow-size),
+				$border-width: var(--nds-popover-border-width),
+			);
 		}
 	}
 }

--- a/packages/core/src/components/popover/tokens.scss
+++ b/packages/core/src/components/popover/tokens.scss
@@ -2,7 +2,6 @@
 @use '../../util';
 
 $arrow-size: 16px !default;
-$arrow-border: calc(var(--nds-popover-arrow-size) / 2) !default;
 $offset-y: 8px !default;
 $max-width: #{util.px2rem(375)}rem;
 $padding-x: spacing.spacer('popover-x') !default;

--- a/packages/core/src/components/tooltip/index.scss
+++ b/packages/core/src/components/tooltip/index.scss
@@ -1,12 +1,13 @@
 @forward 'tokens';
 @use 'tokens';
+@use '../../common/popper';
 @use '../../spacing';
 @use '../../type';
 @use '../../util';
 
 @mixin base {
+	--nds-tooltip-border-width: #{tokens.$border-width};
 	--nds-tooltip-arrow-size: #{tokens.$arrow-size};
-	--nds-tooltip-arrow-border: #{tokens.$arrow-border};
 	--nds-tooltip-offset-y: #{tokens.$offset-y};
 	--nds-tooltip-max-width: #{tokens.$max-width};
 	--nds-tooltip-padding-x: #{tokens.$padding-x};
@@ -15,116 +16,57 @@
 
 	position: absolute;
 	z-index: var(--nds-zindex-tooltip);
-	box-shadow: var(--nds-shadow-tooltip);
-}
-
-@mixin content {
-	position: relative;
-	z-index: 1;
 	max-width: var(--nds-tooltip-max-width);
-	padding: var(--nds-tooltip-padding-y) var(--nds-tooltip-padding-x);
-	color: var(--nds-text-color-inverse);
-	background-color: var(--nds-text-color);
+	color: var(--nds-text-color);
+	background-color: var(--nds-background-color);
+	border: solid var(--nds-tooltip-border-width) transparent;
 	border-radius: var(--nds-tooltip-border-radius);
+}
 
+@mixin body {
 	@include type.ui-sm;
+
+	padding: var(--nds-tooltip-padding-y) var(--nds-tooltip-padding-x);
 }
 
-@mixin arrow {
-	position: absolute;
-	width: var(--nds-tooltip-arrow-size);
-	height: var(--nds-tooltip-arrow-size);
-
-	&::before {
-		position: absolute;
-		content: '';
-		border-color: transparent;
-		border-style: solid;
-	}
+@mixin scheme-dark {
+	--nds-background-color: var(--nds-background-color-inverse);
+	--nds-text-color: var(--nds-text-color-inverse);
 }
 
-@mixin placement-arrow {
-	background-color: var(--nds-text-color);
-}
+@mixin scheme-light {
+	--nds-background-color: unset;
+	--nds-text-color: unset;
 
-@mixin placement-top-arrow {
-	bottom: 0;
-
-	&::before {
-		bottom: calc(-1 * var(--nds-tooltip-arrow-border));
-		left: 0;
-		border-width: var(--nds-tooltip-arrow-border) var(--nds-tooltip-arrow-border) 0;
-		border-top-color: initial;
-		transform-origin: center top;
-	}
-}
-
-@mixin placement-right-arrow {
-	left: 0;
-
-	&::before {
-		left: calc(-1 * var(--nds-tooltip-arrow-border));
-		border-width: var(--nds-tooltip-arrow-border) var(--nds-tooltip-arrow-border) var(--nds-tooltip-arrow-border) 0;
-		border-right-color: initial;
-		transform-origin: center right;
-	}
-}
-
-@mixin placement-bottom-arrow {
-	top: 0;
-
-	&::before {
-		top: calc(-1 * var(--nds-tooltip-arrow-border));
-		left: 0;
-		border-width: 0 var(--nds-tooltip-arrow-border) var(--nds-tooltip-arrow-border);
-		border-bottom-color: initial;
-		transform-origin: center bottom;
-	}
-}
-
-@mixin placement-left-arrow {
-	right: 0;
-
-	&::before {
-		right: calc(-1 * var(--nds-tooltip-arrow-border));
-		border-width: var(--nds-tooltip-arrow-border) 0 var(--nds-tooltip-arrow-border) var(--nds-tooltip-arrow-border);
-		border-left-color: initial;
-		transform-origin: center left;
-	}
+	border-color: var(--nds-base-color-40);
+	box-shadow: var(--nds-shadow-1);
 }
 
 @mixin style {
 	@include util.declare('tooltip') {
 		.nds-tooltip {
 			@include base;
+			@include scheme-dark;
 		}
 
-		.nds-tooltip__content {
-			@include content;
+		.nds-tooltip--light {
+			@include scheme-light;
+		}
+
+		.nds-tooltip--dark {
+			@include scheme-dark;
+		}
+
+		.nds-tooltip__content,	/* deprecated. remove in v2 */
+		.nds-tooltip__body {
+			@include body;
 		}
 
 		.nds-tooltip__arrow {
-			@include arrow;
-		}
-
-		.nds-tooltip[data-popper-placement] > .nds-tooltip__arrow {
-			@include placement-arrow;
-		}
-
-		.nds-tooltip[data-popper-placement^='top'] > .nds-tooltip__arrow {
-			@include placement-top-arrow;
-		}
-
-		.nds-tooltip[data-popper-placement^='right'] > .nds-tooltip__arrow {
-			@include placement-right-arrow;
-		}
-
-		.nds-tooltip[data-popper-placement^='bottom'] > .nds-tooltip__arrow {
-			@include placement-bottom-arrow;
-		}
-
-		.nds-tooltip[data-popper-placement^='left'] > .nds-tooltip__arrow {
-			@include placement-left-arrow;
+			@include popper.arrow(
+				$size: var(--nds-tooltip-arrow-size),
+				$border-width: var(--nds-tooltip-border-width),
+			);
 		}
 	}
 }

--- a/packages/core/src/components/tooltip/tokens.scss
+++ b/packages/core/src/components/tooltip/tokens.scss
@@ -1,9 +1,10 @@
 @use '../../spacing';
+@use '../../util';
 
 $arrow-size: 12px !default;
-$arrow-border: calc(var(--nds-tooltip-arrow-size) / 2) !default;
 $offset-y: 6px !default;
-$max-width: spacing.px-rem(256) !default;
+$max-width: #{util.px2rem(256)}rem;
 $padding-x: spacing.spacer('tooltip-x') !default;
 $padding-y: spacing.spacer('tooltip-y') !default;
 $border-radius: var(--nds-radius-base) !default;
+$border-width: 1px !default;

--- a/packages/react/src/components/Tooltip/index.stories.tsx
+++ b/packages/react/src/components/Tooltip/index.stories.tsx
@@ -19,7 +19,7 @@ const defaultDelay = 200;
 const CALLOUT_WIDTH = 450;
 
 export const Default = (): JSX.Element => (
-	<Tooltip isOpen>
+	<Tooltip isOpen className={select('Color Scheme', { Default: undefined, Dark: 'nds-tooltip--dark', Light: 'nds-tooltip--light' }, undefined)}>
 		Tooltips require a reference element in order to render their arrow.
 	</Tooltip>
 );

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -13,7 +13,12 @@ export interface TooltipProps extends
 	Partial<Pick<UsePopperTriggersProps, 'hideDelay'>> {
 	/** The base class name according to BEM conventions. */
 	baseName?: string;
-	/** A className to apply to the content. Default will be `${baseName}__content`. */
+	/** A className to apply to the body of the tooltip. */
+	bodyClass?: string;
+	/**
+	 * A className to apply to the content. Default will be `${baseName}__content`.
+	 * @deprecated Use the `bodyClass`.
+	 */
 	contentClass?: string;
 	/** A className to apply to the arrow. Default will be `${baseName}__arrow`. */
 	arrowClass?: string;
@@ -43,7 +48,8 @@ export type TooltipCoreProps = PopperOptions & Pick<UsePopperTriggersProps, 'hid
 export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((
 	{
 		baseName = prefix('tooltip'),
-		contentClass = `${baseName}__content`,
+		bodyClass = `${baseName}__body`,
+		contentClass,
 		arrowClass = `${baseName}__arrow`,
 		modifiers,
 		placement = 'top',
@@ -126,7 +132,7 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((
 				ref={setPopper}
 				{...props}
 			>
-				<div className={contentClass}>{ children }</div>
+				<div className={contentClass || bodyClass}>{ children }</div>
 				<div className={arrowClass} />
 			</BasePopper>
 			{/* a persistent, hidden div that is used for the accessible name or description */}


### PR DESCRIPTION
This makes it possible to use a light or dark scheme tooltip. For the time being, this is done purely by adding the right modifier class:

- `.nds-tooltip--dark` - this is the current color scheme (light text on dark background), and is treated as the default.
- `.nds-tooltip--light` - this is new and uses similar styling to Popover.

We'll want to further improve this once #110 lands with the new `<ThemeProvider>`, which is a more React way of handling this.