### PR TITLE
Remove Popper.js exports

### DIFF
--- a/packages/react/src/components/BasePopper/index.tsx
+++ b/packages/react/src/components/BasePopper/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { Instance } from '@popperjs/core';
 import { useForwardedRef, usePopper } from '../../utilities';
-import { PopperOptions, Instance, PopperCoreProps } from '../../utilities/popper/types';
+import { PopperOptions, PopperCoreProps } from '../../utilities/popper/types';
 
 export interface BasePopperProps extends
 	React.HTMLAttributes<HTMLElement>, Pick<PopperCoreProps, 'reference'>, Partial<PopperOptions> {

--- a/packages/react/src/components/Dropdown/index.tsx
+++ b/packages/react/src/components/Dropdown/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
+import { Modifier } from '@popperjs/core';
 import { BaseListbox, BaseListboxProps, OnChangeData } from '../BaseListbox';
 import { FieldInfo, FieldInfoCoreProps } from '../Field';
 import { Button } from '../Button';
 import { canUseDOM } from '../../utilities/environment';
 import { usePopper } from '../../utilities';
-import { PopperOptions, Modifier } from '../../utilities/popper/types';
+import { PopperOptions } from '../../utilities/popper/types';
 
 type BaseProps = 'children' | 'className' | 'disabled' | 'id';
 

--- a/packages/react/src/utilities/popper/hook.tsx
+++ b/packages/react/src/utilities/popper/hook.tsx
@@ -4,12 +4,8 @@ import {
 	useRef, useState,
 } from 'react';
 import isEqual from 'react-fast-compare';
-import {
-	createPopper,
-	Instance,
-	Options,
-	UsePopperProps,
-} from './types';
+import { createPopper, Instance, Options } from '@popperjs/core';
+import { UsePopperProps } from './types';
 
 /** A hook to create a [Popper.js](https://popper.js.org) instance. */
 export const usePopper = ({

--- a/packages/react/src/utilities/popper/hook.tsx
+++ b/packages/react/src/utilities/popper/hook.tsx
@@ -4,8 +4,8 @@ import {
 	useRef, useState,
 } from 'react';
 import isEqual from 'react-fast-compare';
-import { createPopper, Instance, Options } from '@popperjs/core';
-import { UsePopperProps } from './types';
+import { createPopper, Instance } from '@popperjs/core';
+import { UsePopperProps, PopperOptions } from './types';
 
 /** A hook to create a [Popper.js](https://popper.js.org) instance. */
 export const usePopper = ({
@@ -18,7 +18,7 @@ export const usePopper = ({
 	onFirstUpdate,
 }: UsePopperProps): Instance | null => {
 	const [instance, setInstance] = useState<Instance | null>(null);
-	const options = useRef<Options>({
+	const options = useRef<PopperOptions>({
 		placement,
 		modifiers: modifiers || [],
 		strategy,

--- a/packages/react/src/utilities/popper/types.ts
+++ b/packages/react/src/utilities/popper/types.ts
@@ -1,7 +1,5 @@
 import { Options, VirtualElement } from '@popperjs/core';
 
-export * from '@popperjs/core';
-
 export interface PopperOptions {
 	/** The [Popper.js placement option](https://popper.js.org/docs/v2/constructors/#placement). */
 	placement: Options['placement'];


### PR DESCRIPTION
We were exporting all of popper.js. This fixes that.