### PR TITLE
TextField Multiline Component [NDS-16]

### DIFF
--- a/packages/react/src/components/BaseInput/index.tsx
+++ b/packages/react/src/components/BaseInput/index.tsx
@@ -1,56 +1,9 @@
 import React from 'react';
 import {
-	InputType,
 	useForwardedRef,
 	useValidation,
-	ValidatorEntry,
 } from '../../utilities';
-
-export interface BaseInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-	/**
-	 * A list of validation errors. When the input is submitted in a form, the
-	 * list will be concatenated into a single string with a new line separator.
-	 */
-	errors?: string[];
-	/** [DOM - `type`](https://html.spec.whatwg.org/multipage/input.html#attr-input-type) */
-	type?: InputType;
-	/**
-	 * A list of validators. A validator contains a function that tests the value
-	 * for validity and a corresponding message that conveys why the test failed.
-	 */
-	validators?: ValidatorEntry[];
-	/**
-	 * Indicates that validation should occur when the DOM's `change` event is
-	 * triggered. Note that this event is different from React's `onChange`
-	 * callback, which triggers on the DOM's `input` event.
-	 *
-	 * Reference:
-	 * - [MDN - `change event`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
-	 */
-	validateOnDOMChange?: boolean;
-	/**
-	 * Indicates that validation should occur when `onChange` is triggered. Alias
-	 * of `validateOnInput`.
-	 */
-	validateOnChange?: boolean;
-	/** Indicates that a `maxLength` value should prevent input beyond the `maxLength`. */
-	maxLengthRestrictsInput?: boolean;
-	/**
-	 * A callback that will be triggered any time the DOM's `change` event is
-	 * triggered. Note that this event is different from React's `onChange`
-	 * event, which triggers on the DOM's `input` event.
-	 *
-	 * Reference:
-	 * - [MDN - `change event`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
-	 * - [MDN - `input event`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
-	 */
-	onDOMChange?: (e: Event) => void;
-	/**
-	 * A callback that will be triggered any time the input is validated. See
-	 * related `validators`, `validateOnChange`, and `validateOnChange`.
-	 */
-	onValidate?: (errors: string[]) => void;
-}
+import { BaseInputProps } from './types';
 
 const defaultProps: BaseInputProps = {
 	validateOnDOMChange: true,
@@ -60,102 +13,123 @@ const defaultProps: BaseInputProps = {
  * A base `<input>` component. Adds a callback for the DOM's `change` event
  * (`onDOMChange`), which does not exist in React.
  */
-export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((
-	{
-		errors: errorsProp,
-		validateOnChange,
-		validateOnDOMChange = defaultProps.validateOnDOMChange,
-		validators,
-		// pull out maxLength because it prevents user input past the given
-		// length, which is an anti-pattern according to our usage guidelines.
-		maxLength,
-		maxLengthRestrictsInput = false,
-		onInput,
-		onDOMChange,
-		onValidate,
-		...attributes
-	}: BaseInputProps, ref,
-): React.ReactElement => {
-	const [input, setInput] = useForwardedRef(ref);
-	const [errors, setErrors] = React.useState(errorsProp);
+export const BaseInput = React.forwardRef<
+HTMLInputElement | HTMLTextAreaElement,
+BaseInputProps
+>(
+	(
+		{
+			multiline,
+			autoSize,
+			errors: errorsProp,
+			validateOnChange,
+			validateOnDOMChange = defaultProps.validateOnDOMChange,
+			validators,
+			// pull out maxLength because it prevents user input past the given
+			// length, which is an anti-pattern according to our usage guidelines.
+			maxLength,
+			maxLengthRestrictsInput = false,
+			onInput,
+			onDOMChange,
+			onValidate,
+			...attributes
+		}: BaseInputProps,
+		ref,
+	): React.ReactElement => {
+		const [input, setInput] = useForwardedRef(ref);
+		const [errors, setErrors] = React.useState(errorsProp);
 
-	// treat the prop version of `errors` as the source of truth
-	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
+		// treat the prop version of `errors` as the source of truth
+		React.useEffect(() => setErrors(errorsProp), [errorsProp]);
+		const validator = useValidation(validators);
+		const validate = React.useCallback(
+			({
+				max,
+				maxLength: elMaxLength,
+				min,
+				minLength,
+				pattern,
+				required,
+				step,
+				type,
+				value,
+				validity,
+			}: HTMLInputElement) => {
+				const errs = validator({
+					max,
+					maxLength: maxLength || elMaxLength,
+					min,
+					minLength,
+					pattern,
+					required,
+					step,
+					type,
+					value,
+					validity,
+				});
+				if (onValidate) onValidate(errs);
+				if (!errorsProp) setErrors(errs);
+			},
+			[validator, onValidate, errorsProp, maxLength],
+		);
 
-	const validator = useValidation(validators);
-	const validate = React.useCallback(({
-		max,
-		maxLength: elMaxLength,
-		min,
-		minLength,
-		pattern,
-		required,
-		step,
-		type,
-		value,
-		validity,
-	}: HTMLInputElement) => {
-		const errs = validator({
-			max,
-			maxLength: maxLength || elMaxLength,
-			min,
-			minLength,
-			pattern,
-			required,
-			step,
-			type,
-			value,
-			validity,
-		});
-		if (onValidate) onValidate(errs);
-		if (!errorsProp) setErrors(errs);
-	}, [validator, onValidate, errorsProp, maxLength]);
-
-	/**
-	 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
-	 * value, such as entering a letter in a `type="number"` field, so run
-	 * validation here to catch the `ValidityState.badInput` errors.
-	 */
-	const inputHandler = (e: React.FormEvent<HTMLInputElement>): void => {
-		if (onInput) onInput(e);
-
-		if (validateOnChange) validate(e.currentTarget);
-	};
-
-	const domChangeHandler = React.useCallback((e: Event): void => {
-		if (onDOMChange) onDOMChange(e);
-		if (validateOnDOMChange) validate(e.target as HTMLInputElement);
-	}, [onDOMChange, validateOnDOMChange, validate]);
-
-	// Reflect errors on the DOM's constraint validation API. This ensures that
-	// browser tooltip text always matches the custom errors.
-	React.useEffect(() => {
-		if (input && input.willValidate) {
-			const errString = (!errors || !errors.length) ? '' : errors.join('\n');
-			input.setCustomValidity(errString);
-		}
-	}, [input, errors]);
-
-	// Polyfill the DOM `change` listener
-	React.useLayoutEffect(() => {
-		if (input && domChangeHandler) {
-			input.addEventListener('change', domChangeHandler);
-		}
-		return (): void => {
-			if (input && domChangeHandler) {
-				input.removeEventListener('change', domChangeHandler);
-			}
+		/**
+		 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
+		 * value, such as entering a letter in a `type="number"` field, so run
+		 * validation here to catch the `ValidityState.badInput` errors.
+		 */
+		const inputHandler = (
+			e: React.FormEvent<HTMLInputElement> &
+			React.FormEvent<HTMLTextAreaElement>,
+		): void => {
+			if (onInput) onInput(e);
+			if (validateOnChange) validate(e.currentTarget);
 		};
-	}, [input, domChangeHandler]);
 
-	return (
-		<input
-			ref={setInput}
-			onInput={inputHandler}
-			maxLength={(maxLengthRestrictsInput) ? maxLength : undefined}
-			{...attributes}
-		/>
-	);
-});
+		const domChangeHandler = React.useCallback(
+			(e: Event): void => {
+				if (onDOMChange) onDOMChange(e);
+				if (validateOnDOMChange) validate(e.target as HTMLInputElement);
+			}, [onDOMChange, validateOnDOMChange, validate],
+		);
+
+		// Reflect errors on the DOM's constraint validation API. This ensures that
+		// browser tooltip text always matches the custom errors.
+		React.useEffect(() => {
+			if (input && input.willValidate) {
+				const errString = (!errors || !errors.length) ? '' : errors.join('\n');
+				input.setCustomValidity(errString);
+			}
+		}, [input, errors]);
+
+		// Polyfill the DOM `change` listener
+		React.useLayoutEffect(() => {
+			if (input && domChangeHandler) {
+				input.addEventListener('change', domChangeHandler);
+			}
+			return (): void => {
+				if (input && domChangeHandler) {
+					input.removeEventListener('change', domChangeHandler);
+				}
+			};
+		}, [input, domChangeHandler]);
+
+		return multiline ? (
+			<textarea
+				ref={setInput}
+				onInput={inputHandler}
+				maxLength={maxLengthRestrictsInput ? maxLength : undefined}
+				{...attributes}
+			/>
+		) : (
+			<input
+				ref={setInput}
+				onInput={inputHandler}
+				maxLength={(maxLengthRestrictsInput) ? maxLength : undefined}
+				{...attributes}
+			/>
+		);
+	},
+);
 
 BaseInput.defaultProps = defaultProps;

--- a/packages/react/src/components/BaseInput/index.tsx
+++ b/packages/react/src/components/BaseInput/index.tsx
@@ -14,110 +14,102 @@ const defaultProps: BaseInputProps = {
  * A base `<input>` component. Adds a callback for the DOM's `change` event
  * (`onDOMChange`), which does not exist in React.
  */
-export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
-	(
-		{
-			errors: errorsProp,
-			validateOnChange,
-			validateOnDOMChange = defaultProps.validateOnDOMChange,
-			validators,
-			// pull out maxLength because it prevents user input past the given
-			// length, which is an anti-pattern according to our usage guidelines.
-			maxLength,
-			maxLengthRestrictsInput = false,
-			onInput,
-			onDOMChange,
-			onValidate,
-			...attributes
-		}: BaseInputProps,
-		ref,
-	): React.ReactElement => {
-		const [input, setInput] = useForwardedRef(ref);
-		const [errors, setErrors] = React.useState(errorsProp);
+export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((
+	{
+		errors: errorsProp,
+		validateOnChange,
+		validateOnDOMChange = defaultProps.validateOnDOMChange,
+		validators,
+		// pull out maxLength because it prevents user input past the given
+		// length, which is an anti-pattern according to our usage guidelines.
+		maxLength,
+		maxLengthRestrictsInput = false,
+		onInput,
+		onDOMChange,
+		onValidate,
+		...attributes
+	}: BaseInputProps, ref,
+): React.ReactElement => {
+	const [input, setInput] = useForwardedRef(ref);
+	const [errors, setErrors] = React.useState(errorsProp);
 
-		// treat the prop version of `errors` as the source of truth
-		React.useEffect(() => setErrors(errorsProp), [errorsProp]);
-		const validator = useValidation(validators);
-		const validate = React.useCallback(
-			({
-				max,
-				maxLength: elMaxLength,
-				min,
-				minLength,
-				pattern,
-				required,
-				step,
-				type,
-				value,
-				validity,
-			}: HTMLInputElement) => {
-				const errs = validator({
-					max,
-					maxLength: maxLength || elMaxLength,
-					min,
-					minLength,
-					pattern,
-					required,
-					step,
-					type,
-					value,
-					validity,
-				});
-				if (onValidate) onValidate(errs);
-				if (!errorsProp) setErrors(errs);
-			},
-			[validator, onValidate, errorsProp, maxLength],
-		);
+	// treat the prop version of `errors` as the source of truth
+	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
 
-		/**
-		 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
-		 * value, such as entering a letter in a `type="number"` field, so run
-		 * validation here to catch the `ValidityState.badInput` errors.
-		 */
-		const inputHandler = (
-			e: React.FormEvent<HTMLInputElement>,
-		): void => {
-			if (onInput) onInput(e);
-			if (validateOnChange) validate(e.currentTarget);
-		};
+	const validator = useValidation(validators);
+	const validate = React.useCallback(({
+		max,
+		maxLength: elMaxLength,
+		min,
+		minLength,
+		pattern,
+		required,
+		step,
+		type,
+		value,
+		validity,
+	}: HTMLInputElement) => {
+		const errs = validator({
+			max,
+			maxLength: maxLength || elMaxLength,
+			min,
+			minLength,
+			pattern,
+			required,
+			step,
+			type,
+			value,
+			validity,
+		});
+		if (onValidate) onValidate(errs);
+		if (!errorsProp) setErrors(errs);
+	}, [validator, onValidate, errorsProp, maxLength]);
 
-		const domChangeHandler = React.useCallback(
-			(e: Event): void => {
-				if (onDOMChange) onDOMChange(e);
-				if (validateOnDOMChange) validate(e.target as HTMLInputElement);
-			}, [onDOMChange, validateOnDOMChange, validate],
-		);
+	/**
+	 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
+	 * value, such as entering a letter in a `type="number"` field, so run
+	 * validation here to catch the `ValidityState.badInput` errors.
+	 */
+	const inputHandler = (e: React.FormEvent<HTMLInputElement>): void => {
+		if (onInput) onInput(e);
 
-		// Reflect errors on the DOM's constraint validation API. This ensures that
-		// browser tooltip text always matches the custom errors.
-		React.useEffect(() => {
-			if (input && input.willValidate) {
-				const errString = (!errors || !errors.length) ? '' : errors.join('\n');
-				input.setCustomValidity(errString);
-			}
-		}, [input, errors]);
+		if (validateOnChange) validate(e.currentTarget);
+	};
 
-		// Polyfill the DOM `change` listener
-		useLayoutEffect(() => {
+	const domChangeHandler = React.useCallback((e: Event): void => {
+		if (onDOMChange) onDOMChange(e);
+		if (validateOnDOMChange) validate(e.target as HTMLInputElement);
+	}, [onDOMChange, validateOnDOMChange, validate]);
+
+	// Reflect errors on the DOM's constraint validation API. This ensures that
+	// browser tooltip text always matches the custom errors.
+	React.useEffect(() => {
+		if (input && input.willValidate) {
+			const errString = (!errors || !errors.length) ? '' : errors.join('\n');
+			input.setCustomValidity(errString);
+		}
+	}, [input, errors]);
+
+	// Polyfill the DOM `change` listener
+	useLayoutEffect(() => {
+		if (input && domChangeHandler) {
+			input.addEventListener('change', domChangeHandler);
+		}
+		return (): void => {
 			if (input && domChangeHandler) {
-				input.addEventListener('change', domChangeHandler);
+				input.removeEventListener('change', domChangeHandler);
 			}
-			return (): void => {
-				if (input && domChangeHandler) {
-					input.removeEventListener('change', domChangeHandler);
-				}
-			};
-		}, [input, domChangeHandler]);
+		};
+	}, [input, domChangeHandler]);
 
-		return (
-			<input
-				ref={setInput}
-				onInput={inputHandler}
-				maxLength={(maxLengthRestrictsInput) ? maxLength : undefined}
-				{...attributes}
-			/>
-		);
-	},
-);
+	return (
+		<input
+			ref={setInput}
+			onInput={inputHandler}
+			maxLength={(maxLengthRestrictsInput) ? maxLength : undefined}
+			{...attributes}
+		/>
+	);
+});
 
 BaseInput.defaultProps = defaultProps;

--- a/packages/react/src/components/BaseInput/index.tsx
+++ b/packages/react/src/components/BaseInput/index.tsx
@@ -97,8 +97,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 			}
 		}, [input, errors]);
 
-	  // Polyfill the DOM `change` listener
-	  useLayoutEffect(() => {
+		// Polyfill the DOM `change` listener
+		useLayoutEffect(() => {
 			if (input && domChangeHandler) {
 				input.addEventListener('change', domChangeHandler);
 			}

--- a/packages/react/src/components/BaseInput/index.tsx
+++ b/packages/react/src/components/BaseInput/index.tsx
@@ -73,6 +73,18 @@ BaseInputProps
 			[validator, onValidate, errorsProp, maxLength],
 		);
 
+		// Handles auto sizing with multiline component
+		React.useEffect(() => {
+			if (multiline && autoSize && input) input.style.height = 'auto';
+		}, [autoSize, input, multiline]);
+
+		const onResize = () => {
+			if (input) {
+				input.style.height = 'auto';
+				input.style.height = `${input.scrollHeight}px`;
+			}
+		};
+
 		/**
 		 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
 		 * value, such as entering a letter in a `type="number"` field, so run
@@ -83,6 +95,7 @@ BaseInputProps
 			React.FormEvent<HTMLTextAreaElement>,
 		): void => {
 			if (onInput) onInput(e);
+			if (multiline && autoSize) onResize();
 			if (validateOnChange) validate(e.currentTarget);
 		};
 

--- a/packages/react/src/components/BaseInput/types.ts
+++ b/packages/react/src/components/BaseInput/types.ts
@@ -51,9 +51,9 @@ export interface BaseInputProps
 	 */
 	multiline?: boolean;
 	/**
-   * If `true` increase the height of textarea automatically
+	 * If `true` increase the height of textarea automatically
 	 * only works when multiline prop it's `true`
-   * @default false
-   */
+	 * @default false
+	 */
 	autoSize?: boolean;
 }

--- a/packages/react/src/components/BaseInput/types.ts
+++ b/packages/react/src/components/BaseInput/types.ts
@@ -1,0 +1,59 @@
+import { InputType, ValidatorEntry } from '../../utilities';
+
+export interface BaseInputProps
+	extends React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
+	/**
+	 * A list of validation errors. When the input is submitted in a form, the
+	 * list will be concatenated into a single string with a new line separator.
+	 */
+	errors?: string[];
+	/** [DOM - `type`](https://html.spec.whatwg.org/multipage/input.html#attr-input-type) */
+	type?: InputType;
+	/**
+	 * A list of validators. A validator contains a function that tests the value
+	 * for validity and a corresponding message that conveys why the test failed.
+	 */
+	validators?: ValidatorEntry[];
+	/**
+	 * Indicates that validation should occur when the DOM's `change` event is
+	 * triggered. Note that this event is different from React's `onChange`
+	 * callback, which triggers on the DOM's `input` event.
+	 *
+	 * Reference:
+	 * - [MDN - `change event`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
+	 */
+	validateOnDOMChange?: boolean;
+	/**
+	 * Indicates that validation should occur when `onChange` is triggered. Alias
+	 * of `validateOnInput`.
+	 */
+	validateOnChange?: boolean;
+	/** Indicates that a `maxLength` value should prevent input beyond the `maxLength`. */
+	maxLengthRestrictsInput?: boolean;
+	/**
+	 * A callback that will be triggered any time the DOM's `change` event is
+	 * triggered. Note that this event is different from React's `onChange`
+	 * event, which triggers on the DOM's `input` event.
+	 *
+	 * Reference:
+	 * - [MDN - `change event`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
+	 * - [MDN - `input event`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
+	 */
+	onDOMChange?: (e: Event) => void;
+	/**
+	 * A callback that will be triggered any time the input is validated. See
+	 * related `validators`, `validateOnChange`, and `validateOnChange`.
+	 */
+	onValidate?: (errors: string[]) => void;
+	/**
+	 * attribute to render TextArea always
+	 * @default false
+	 */
+	multiline?: boolean;
+	/**
+   * If `true` increase the height of textarea automatically
+	 * only works when multiline prop it's `true`
+   * @default false
+   */
+	autoSize?: boolean;
+}

--- a/packages/react/src/components/BaseTextArea/index.tsx
+++ b/packages/react/src/components/BaseTextArea/index.tsx
@@ -1,6 +1,7 @@
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import {
 	useForwardedRef,
+	useLayoutEffect,
 	useValidation,
 } from '../../utilities';
 import { BaseTextAreaProps } from './types';

--- a/packages/react/src/components/BaseTextArea/index.tsx
+++ b/packages/react/src/components/BaseTextArea/index.tsx
@@ -21,7 +21,7 @@ export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaPr
 		validateOnChange,
 		validateOnDOMChange = defaultProps.validateOnDOMChange,
 		validators,
-		// pull out maxLength because it prevents user input past the given
+		// pull out maxLength because it prevents user textarea past the given
 		// length, which is an anti-pattern according to our usage guidelines.
 		maxLength,
 		maxLengthRestrictsInput = false,
@@ -31,7 +31,7 @@ export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaPr
 		...attributes
 	}: BaseTextAreaProps, ref,
 ): React.ReactElement => {
-	const [input, setInput] = useForwardedRef(ref);
+	const [textarea, setTextarea] = useForwardedRef(ref);
 	const [errors, setErrors] = React.useState(errorsProp);
 	const lines = Number(multiline) > 0 ? Number(multiline) : 1;
 
@@ -61,13 +61,13 @@ export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaPr
 
 	// Handles auto sizing with multiline component
 	React.useEffect(() => {
-		if (autoSize && input) input.style.height = 'auto';
-	}, [autoSize, input]);
+		if (autoSize && textarea) textarea.style.height = 'auto';
+	}, [autoSize, textarea]);
 
 	const onResize = () => {
-		if (input) {
-			input.style.height = 'auto';
-			input.style.height = `${input.scrollHeight}px`;
+		if (textarea) {
+			textarea.style.height = 'auto';
+			textarea.style.height = `${textarea.scrollHeight}px`;
 		}
 	};
 
@@ -90,27 +90,27 @@ export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaPr
 	// Reflect errors on the DOM's constraint validation API. This ensures that
 	// browser tooltip text always matches the custom errors.
 	React.useEffect(() => {
-		if (input && input.willValidate) {
+		if (textarea && textarea.willValidate) {
 			const errString = (!errors || !errors.length) ? '' : errors.join('\n');
-			input.setCustomValidity(errString);
+			textarea.setCustomValidity(errString);
 		}
-	}, [input, errors]);
+	}, [textarea, errors]);
 
 	// Polyfill the DOM `change` listener
 	useLayoutEffect(() => {
-		if (input && domChangeHandler) {
-			input.addEventListener('change', domChangeHandler);
+		if (textarea && domChangeHandler) {
+			textarea.addEventListener('change', domChangeHandler);
 		}
 		return (): void => {
-			if (input && domChangeHandler) {
-				input.removeEventListener('change', domChangeHandler);
+			if (textarea && domChangeHandler) {
+				textarea.removeEventListener('change', domChangeHandler);
 			}
 		};
-	}, [input, domChangeHandler]);
+	}, [textarea, domChangeHandler]);
 
 	return (
 		<textarea
-			ref={setInput}
+			ref={setTextarea}
 			rows={lines}
 			onInput={inputHandler}
 			maxLength={(maxLengthRestrictsInput) ? maxLength : undefined}

--- a/packages/react/src/components/BaseTextArea/index.tsx
+++ b/packages/react/src/components/BaseTextArea/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import {
 	useForwardedRef,
 	useValidation,
@@ -13,119 +13,110 @@ const defaultProps: BaseTextAreaProps = {
  * A base `<textarea>` component. Adds a callback for the DOM's `change` event
  * (`onDOMChange`), which does not exist in React.
  */
-export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
-	(
-		{
-			multiline = false,
-			autoSize = false,
-			errors: errorsProp,
-			validateOnChange,
-			validateOnDOMChange = defaultProps.validateOnDOMChange,
-			validators,
-			// pull out maxLength because it prevents user input past the given
-			// length, which is an anti-pattern according to our usage guidelines.
-			maxLength,
-			maxLengthRestrictsInput = false,
-			onInput,
-			onDOMChange,
-			onValidate,
-			...attributes
-		}: BaseTextAreaProps,
-		ref,
-	): React.ReactElement => {
-		const [input, setInput] = useForwardedRef(ref);
-		const [errors, setErrors] = React.useState(errorsProp);
-		const lines = Number(multiline) > 0 ? Number(multiline) : 1;
+export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaProps>((
+	{
+		multiline = false,
+		autoSize = false,
+		errors: errorsProp,
+		validateOnChange,
+		validateOnDOMChange = defaultProps.validateOnDOMChange,
+		validators,
+		// pull out maxLength because it prevents user input past the given
+		// length, which is an anti-pattern according to our usage guidelines.
+		maxLength,
+		maxLengthRestrictsInput = false,
+		onInput,
+		onDOMChange,
+		onValidate,
+		...attributes
+	}: BaseTextAreaProps, ref,
+): React.ReactElement => {
+	const [input, setInput] = useForwardedRef(ref);
+	const [errors, setErrors] = React.useState(errorsProp);
+	const lines = Number(multiline) > 0 ? Number(multiline) : 1;
 
-		// treat the prop version of `errors` as the source of truth
-		React.useEffect(() => setErrors(errorsProp), [errorsProp]);
-		const validator = useValidation(validators);
-		const validate = React.useCallback(
-			({
-				maxLength: elMaxLength,
-				minLength,
-				required,
-				type,
-				value,
-				validity,
-			}: HTMLTextAreaElement) => {
-				const errs = validator({
-					maxLength: maxLength || elMaxLength,
-					minLength,
-					required,
-					type,
-					value,
-					validity,
-				});
-				if (onValidate) onValidate(errs);
-				if (!errorsProp) setErrors(errs);
-			},
-			[validator, onValidate, errorsProp, maxLength],
-		);
+	// treat the prop version of `errors` as the source of truth
+	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
 
-		// Handles auto sizing with multiline component
-		React.useEffect(() => {
-			if (autoSize && input) input.style.height = 'auto';
-		}, [autoSize, input]);
+	const validator = useValidation(validators);
+	const validate = React.useCallback(({
+		maxLength: elMaxLength,
+		minLength,
+		required,
+		type,
+		value,
+		validity,
+	}: HTMLTextAreaElement) => {
+		const errs = validator({
+			maxLength: maxLength || elMaxLength,
+			minLength,
+			required,
+			type,
+			value,
+			validity,
+		});
+		if (onValidate) onValidate(errs);
+		if (!errorsProp) setErrors(errs);
+	}, [validator, onValidate, errorsProp, maxLength]);
 
-		const onResize = () => {
-			if (input) {
-				input.style.height = 'auto';
-				input.style.height = `${input.scrollHeight}px`;
-			}
-		};
+	// Handles auto sizing with multiline component
+	React.useEffect(() => {
+		if (autoSize && input) input.style.height = 'auto';
+	}, [autoSize, input]);
 
-		/**
-		 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
-		 * value, such as entering a letter in a `type="number"` field, so run
-		 * validation here to catch the `ValidityState.badInput` errors.
-		 */
-		const inputHandler = (
-			e: React.FormEvent<HTMLTextAreaElement>,
-		): void => {
-			if (onInput) onInput(e);
-			if (autoSize) onResize();
-			if (validateOnChange) validate(e.currentTarget);
-		};
+	const onResize = () => {
+		if (input) {
+			input.style.height = 'auto';
+			input.style.height = `${input.scrollHeight}px`;
+		}
+	};
 
-		const domChangeHandler = React.useCallback(
-			(e: Event): void => {
-				if (onDOMChange) onDOMChange(e);
-				if (validateOnDOMChange) validate(e.target as HTMLTextAreaElement);
-			}, [onDOMChange, validateOnDOMChange, validate],
-		);
+	/**
+	 * Unlike `onChange`, `onInput` will trigger even when the user enters a bad
+	 * value, such as entering a letter in a `type="number"` field, so run
+	 * validation here to catch the `ValidityState.badInput` errors.
+	 */
+	const inputHandler = (e: React.FormEvent<HTMLTextAreaElement>): void => {
+		if (onInput) onInput(e);
+		if (autoSize) onResize();
+		if (validateOnChange) validate(e.currentTarget);
+	};
 
-		// Reflect errors on the DOM's constraint validation API. This ensures that
-		// browser tooltip text always matches the custom errors.
-		React.useEffect(() => {
-			if (input && input.willValidate) {
-				const errString = (!errors || !errors.length) ? '' : errors.join('\n');
-				input.setCustomValidity(errString);
-			}
-		}, [input, errors]);
+	const domChangeHandler = React.useCallback((e: Event): void => {
+		if (onDOMChange) onDOMChange(e);
+		if (validateOnDOMChange) validate(e.target as HTMLTextAreaElement);
+	}, [onDOMChange, validateOnDOMChange, validate]);
 
-		// Polyfill the DOM `change` listener
-		React.useLayoutEffect(() => {
+	// Reflect errors on the DOM's constraint validation API. This ensures that
+	// browser tooltip text always matches the custom errors.
+	React.useEffect(() => {
+		if (input && input.willValidate) {
+			const errString = (!errors || !errors.length) ? '' : errors.join('\n');
+			input.setCustomValidity(errString);
+		}
+	}, [input, errors]);
+
+	// Polyfill the DOM `change` listener
+	useLayoutEffect(() => {
+		if (input && domChangeHandler) {
+			input.addEventListener('change', domChangeHandler);
+		}
+		return (): void => {
 			if (input && domChangeHandler) {
-				input.addEventListener('change', domChangeHandler);
+				input.removeEventListener('change', domChangeHandler);
 			}
-			return (): void => {
-				if (input && domChangeHandler) {
-					input.removeEventListener('change', domChangeHandler);
-				}
-			};
-		}, [input, domChangeHandler]);
+		};
+	}, [input, domChangeHandler]);
 
-		return (
-			<textarea
-				ref={setInput}
-				rows={lines}
-				onInput={inputHandler}
-				maxLength={maxLengthRestrictsInput ? maxLength : undefined}
-				{...attributes}
-			/>
-		);
-	},
-);
+	return (
+		<textarea
+			ref={setInput}
+			rows={lines}
+			onInput={inputHandler}
+			maxLength={(maxLengthRestrictsInput) ? maxLength : undefined}
+			{...attributes}
+		/>
+	);
+});
 
 BaseTextArea.defaultProps = defaultProps;

--- a/packages/react/src/components/BaseTextArea/types.ts
+++ b/packages/react/src/components/BaseTextArea/types.ts
@@ -1,14 +1,12 @@
-import { InputType, ValidatorEntry } from '../../utilities';
+import { ValidatorEntry } from '../../utilities';
 
-export interface BaseInputProps
-	extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface BaseTextAreaProps
+	extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
 	/**
 	 * A list of validation errors. When the input is submitted in a form, the
 	 * list will be concatenated into a single string with a new line separator.
 	 */
 	errors?: string[];
-	/** [DOM - `type`](https://html.spec.whatwg.org/multipage/input.html#attr-input-type) */
-	type?: InputType;
 	/**
 	 * A list of validators. A validator contains a function that tests the value
 	 * for validity and a corresponding message that conveys why the test failed.
@@ -45,4 +43,12 @@ export interface BaseInputProps
 	 * related `validators`, `validateOnChange`, and `validateOnChange`.
 	 */
 	onValidate?: (errors: string[]) => void;
+	/** Allow for multiple lines of input */
+	multiline?: boolean | number;
+	/**
+	 * If `true` increase the height of textarea automatically
+	 * only works when multiline prop it's `true`
+	 * @default false
+	 */
+	autoSize?: boolean;
 }

--- a/packages/react/src/components/BaseTextArea/types.ts
+++ b/packages/react/src/components/BaseTextArea/types.ts
@@ -47,8 +47,7 @@ export interface BaseTextAreaProps
 	multiline?: boolean | number;
 	/**
 	 * If `true` increase the height of textarea automatically
-	 * only works when multiline prop it's `true`
-	 * @default false
+	 * only works when multiline prop it's `enable`
 	 */
 	autoSize?: boolean;
 }

--- a/packages/react/src/components/ChoiceField/Choice.tsx
+++ b/packages/react/src/components/ChoiceField/Choice.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
-import { BaseInput, BaseInputProps } from '../BaseInput';
+import { BaseInput } from '../BaseInput';
 import { Icon } from '../Icon';
 import {
 	FieldInfo, FieldInfoCoreProps,
 	FieldFeedback, FieldFeedbackCoreProps,
 } from '../Field';
 import { useForwardedRef } from '../../utilities';
+import { BaseInputProps } from '../BaseInput/types';
 
 export interface ChoiceProps extends
 	Omit<FieldInfoCoreProps, 'label'>,

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -292,9 +292,26 @@ export const TextFieldMultiline: React.FunctionComponent = () => {
 		<TextField
 			multiline={boolean('multiline', true)}
 			autoSize={boolean('autosize', true)}
-			rows={number('rows', 1)}
-			minRows={number('minRows', 1)}
-			maxRows={number('maxRows', 5)}
+			description='The default Text Field has a type of "text"'
+			disabled={boolean('Disabled', false)}
+			onDOMChange={action('onDOMChange')}
+			required={boolean('Required', false)}
+			validateOnChange={boolean('Validate on React change', true)}
+			validateOnDOMChange={boolean('Validate on DOM change', true)}
+			requiredIndicator={indicator === 'required'}
+			optionalIndicator={indicator === 'optional'}
+		>
+			{ text('Label', 'Default Text Field') }
+		</TextField>
+	);
+};
+
+export const TextFieldMultilineRows: React.FunctionComponent = () => {
+	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
+	return (
+		<TextField
+			multiline={number('multiline', 5)}
+			autoSize={boolean('autosize', true)}
 			description='The default Text Field has a type of "text"'
 			disabled={boolean('Disabled', false)}
 			onDOMChange={action('onDOMChange')}
@@ -313,9 +330,6 @@ export const MultilineWithMaxLength: React.FunctionComponent = () => (
 	<TextFieldUncontrolled
 		multiline={boolean('multiline', true)}
 		autoSize={boolean('autosize', true)}
-		rows={number('rows', 2)}
-		minRows={number('minRows', 1)}
-		maxRows={number('maxRows', 5)}
 		maxLength={number('Maximum length', 10)}
 		counterStart={number('Start counter at', 8)}
 		onCount={action('onCount')}

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -13,7 +13,6 @@ import {
 import { Button, ButtonProps } from '../Button';
 import { Icon, IconProps } from '../Icon';
 import { useValidation } from '../../utilities';
-import { TextArea } from '../TextArea';
 import { TextFieldProps, TextFieldType } from './types';
 
 export default {
@@ -287,53 +286,15 @@ export const CustomValidation: React.FunctionComponent = () => {
 	);
 };
 
-export const TextAreaAutoSize: React.FunctionComponent = () => {
-	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
-	return (
-		<TextArea
-			autoSize={boolean('autoSize', false)}
-			description="This example won't allow you to enter vowels (don't do this in the real world)"
-			disabled={boolean('Disabled', false)}
-			onDOMChange={action('onDOMChange')}
-			required={boolean('Required', false)}
-			rows={number('rows', 2)}
-			minRows={number('minRows', 3)}
-			maxRows={number('maxRows', 5)}
-			validateOnChange={boolean('Validate on React change', true)}
-			validateOnDOMChange={boolean('Validate on DOM change', true)}
-			requiredIndicator={indicator === 'required'}
-			optionalIndicator={indicator === 'optional'}
-		>
-			{ text('Label', 'Default Text Field') }
-		</TextArea>
-	);
-};
-
-export const TextAreaMultiline: React.FunctionComponent = () => {
-	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
-	return (
-		<TextArea
-			autoSize={boolean('autoSize', false)}
-			description="This example won't allow you to enter vowels (don't do this in the real world)"
-			disabled={boolean('Disabled', false)}
-			onDOMChange={action('onDOMChange')}
-			required={boolean('Required', false)}
-			validateOnChange={boolean('Validate on React change', true)}
-			validateOnDOMChange={boolean('Validate on DOM change', true)}
-			requiredIndicator={indicator === 'required'}
-			optionalIndicator={indicator === 'optional'}
-		>
-			{ text('Label', 'Default Text Field') }
-		</TextArea>
-	);
-};
-
 export const TextFieldMultiline: React.FunctionComponent = () => {
 	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
 	return (
 		<TextField
 			multiline={boolean('multiline', true)}
 			autoSize={boolean('autosize', true)}
+			rows={number('rows', 1)}
+			minRows={number('minRows', 1)}
+			maxRows={number('maxRows', 5)}
 			description='The default Text Field has a type of "text"'
 			disabled={boolean('Disabled', false)}
 			onDOMChange={action('onDOMChange')}
@@ -347,6 +308,22 @@ export const TextFieldMultiline: React.FunctionComponent = () => {
 		</TextField>
 	);
 };
+
+export const MultilineWithMaxLength: React.FunctionComponent = () => (
+	<TextFieldUncontrolled
+		multiline={boolean('multiline', true)}
+		autoSize={boolean('autosize', true)}
+		rows={number('rows', 2)}
+		minRows={number('minRows', 1)}
+		maxRows={number('maxRows', 5)}
+		maxLength={number('Maximum length', 10)}
+		counterStart={number('Start counter at', 8)}
+		onCount={action('onCount')}
+		validateOnChange
+	>
+		Text Field with max length
+	</TextFieldUncontrolled>
+);
 
 export const CustomValidationMultiline: React.FunctionComponent = () => {
 	const firstName = text('First name', 'Jane');

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -49,7 +49,8 @@ export const ControlledEmail: React.FunctionComponent = () => {
 	// whatever reason
 	const validate = useValidation();
 
-	const changeHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
+	const changeHandler = (e: React.ChangeEvent<HTMLInputElement> &
+	React.ChangeEvent<HTMLTextAreaElement>): void => {
 		const val = e.target.value;
 		const newErrors = validate(e.target);
 		let allowValue = true;

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -8,11 +8,13 @@ import {
 	select,
 } from '@storybook/addon-knobs';
 import {
-	TextField, TextFieldUncontrolled, TextFieldType, TextFieldProps,
+	TextField, TextFieldUncontrolled,
 } from '.';
 import { Button, ButtonProps } from '../Button';
 import { Icon, IconProps } from '../Icon';
 import { useValidation } from '../../utilities';
+import { TextArea } from '../TextArea';
+import { TextFieldProps, TextFieldType } from './types';
 
 export default {
 	title: 'Text Field',
@@ -273,6 +275,107 @@ export const CustomValidation: React.FunctionComponent = () => {
 
 	return (
 		<TextField
+			value={value}
+			errors={errors}
+			onChange={changeHandler}
+			description="Change the required name in the Storybook knobs below."
+			feedback={feedback}
+			required
+		>
+			Full name
+		</TextField>
+	);
+};
+
+export const TextAreaAutoSize: React.FunctionComponent = () => {
+	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
+	return (
+		<TextArea
+			autoSize={boolean('autoSize', false)}
+			description="This example won't allow you to enter vowels (don't do this in the real world)"
+			disabled={boolean('Disabled', false)}
+			onDOMChange={action('onDOMChange')}
+			required={boolean('Required', false)}
+			rows={number('rows', 2)}
+			minRows={number('minRows', 3)}
+			maxRows={number('maxRows', 5)}
+			validateOnChange={boolean('Validate on React change', true)}
+			validateOnDOMChange={boolean('Validate on DOM change', true)}
+			requiredIndicator={indicator === 'required'}
+			optionalIndicator={indicator === 'optional'}
+		>
+			{ text('Label', 'Default Text Field') }
+		</TextArea>
+	);
+};
+
+export const TextAreaMultiline: React.FunctionComponent = () => {
+	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
+	return (
+		<TextArea
+			autoSize={boolean('autoSize', false)}
+			description="This example won't allow you to enter vowels (don't do this in the real world)"
+			disabled={boolean('Disabled', false)}
+			onDOMChange={action('onDOMChange')}
+			required={boolean('Required', false)}
+			validateOnChange={boolean('Validate on React change', true)}
+			validateOnDOMChange={boolean('Validate on DOM change', true)}
+			requiredIndicator={indicator === 'required'}
+			optionalIndicator={indicator === 'optional'}
+		>
+			{ text('Label', 'Default Text Field') }
+		</TextArea>
+	);
+};
+
+export const TextFieldMultiline: React.FunctionComponent = () => {
+	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
+	return (
+		<TextField
+			multiline={boolean('multiline', true)}
+			autoSize={boolean('autosize', true)}
+			description='The default Text Field has a type of "text"'
+			disabled={boolean('Disabled', false)}
+			onDOMChange={action('onDOMChange')}
+			required={boolean('Required', false)}
+			validateOnChange={boolean('Validate on React change', true)}
+			validateOnDOMChange={boolean('Validate on DOM change', true)}
+			requiredIndicator={indicator === 'required'}
+			optionalIndicator={indicator === 'optional'}
+		>
+			{ text('Label', 'Default Text Field') }
+		</TextField>
+	);
+};
+
+export const CustomValidationMultiline: React.FunctionComponent = () => {
+	const firstName = text('First name', 'Jane');
+	const lastName = text('Last name', 'Doe');
+	const [value, setValue] = React.useState('');
+	const [errors, setErrors] = React.useState<string[]>();
+
+	const changeHandler = (e): void => setValue(e.target.value);
+
+	const feedback = React.useMemo(() => {
+		if (errors && !errors.length) {
+			return `Well done, ${value}!`;
+		}
+		return undefined;
+	}, [errors, value]);
+
+	React.useEffect(() => {
+		if (value) {
+			const newErrors: string[] = [];
+			if (!value.startsWith(firstName)) newErrors.push(`Must begin with "${firstName}".`);
+			if (!value.endsWith(lastName)) newErrors.push(`Must end with "${lastName}".`);
+			setErrors(newErrors);
+		}
+	}, [value, firstName, lastName]);
+
+	return (
+		<TextField
+			multiline={boolean('multiline', true)}
+			autoSize={boolean('autoSize', true)}
 			value={value}
 			errors={errors}
 			onChange={changeHandler}

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -287,12 +287,12 @@ export const CustomValidation: React.FunctionComponent = () => {
 	);
 };
 
-export const TextFieldMultiline: React.FunctionComponent = () => {
+export const Multiline: React.FunctionComponent = () => {
 	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
 	return (
 		<TextField
-			multiline={boolean('multiline', true)}
-			autoSize={boolean('autosize', true)}
+			multiline={boolean('Multiline', true)}
+			autoSize={boolean('Auto resize', true)}
 			description='The default Text Field has a type of "text"'
 			disabled={boolean('Disabled', false)}
 			onDOMChange={action('onDOMChange')}
@@ -307,12 +307,12 @@ export const TextFieldMultiline: React.FunctionComponent = () => {
 	);
 };
 
-export const TextFieldMultilineRows: React.FunctionComponent = () => {
+export const MultilineRows: React.FunctionComponent = () => {
 	const indicator = select('Show indicator', { None: undefined, Required: 'required', Optional: 'optional' }, undefined);
 	return (
 		<TextField
-			multiline={number('multiline', 5)}
-			autoSize={boolean('autosize', true)}
+			multiline={number('Multiline', 5)}
+			autoSize={boolean('Auto resize', true)}
 			description='The default Text Field has a type of "text"'
 			disabled={boolean('Disabled', false)}
 			onDOMChange={action('onDOMChange')}
@@ -329,8 +329,8 @@ export const TextFieldMultilineRows: React.FunctionComponent = () => {
 
 export const MultilineWithMaxLength: React.FunctionComponent = () => (
 	<TextFieldUncontrolled
-		multiline={boolean('multiline', true)}
-		autoSize={boolean('autosize', true)}
+		multiline={boolean('Multiline', true)}
+		autoSize={boolean('Auto resize', true)}
 		maxLength={number('Maximum length', 10)}
 		counterStart={number('Start counter at', 8)}
 		onCount={action('onCount')}
@@ -366,8 +366,8 @@ export const CustomValidationMultiline: React.FunctionComponent = () => {
 
 	return (
 		<TextField
-			multiline={boolean('multiline', true)}
-			autoSize={boolean('autoSize', true)}
+			multiline={boolean('Multiline', true)}
+			autoSize={boolean('Auto resize', true)}
 			value={value}
 			errors={errors}
 			onChange={changeHandler}

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -26,6 +26,8 @@ export const Default: React.FunctionComponent = () => {
 	return (
 		<TextFieldUncontrolled
 			description='The default Text Field has a type of "text"'
+			multiline={boolean('Multiline', false)}
+			autoSize={boolean('Auto resize', false)}
 			disabled={boolean('Disabled', false)}
 			onDOMChange={action('onDOMChange')}
 			required={boolean('Required', false)}

--- a/packages/react/src/components/TextField/index.test.tsx
+++ b/packages/react/src/components/TextField/index.test.tsx
@@ -177,7 +177,14 @@ test('text field renders as <textarea> element', (t) => {
 	t.truthy(screen.getByRole('textbox') as HTMLTextAreaElement);
 });
 
-test('text field renders as <textarea> element within autoSize', (t) => {
+test('text field renders as <textarea> element within oninput autoSize', (t) => {
+	render(<TextField multiline autoSize>{ defaultLabel }</TextField>);
+	const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+	fireEvent.input(textarea, { key: 'Enter', code: 'Enter' });
+	t.notDeepEqual(textarea.rows, 2);
+});
+
+test('text field renders as <textarea> element within onchange autoSize', (t) => {
 	render(<TextField multiline autoSize>{ defaultLabel }</TextField>);
 	const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
 	fireEvent.change(textarea, { key: 'Enter', code: 'Enter' });

--- a/packages/react/src/components/TextField/index.test.tsx
+++ b/packages/react/src/components/TextField/index.test.tsx
@@ -171,3 +171,15 @@ test('an uncontrolled text field manages its own state', (t) => {
 	fireEvent.change(input, { target: { value: 'abc' } });
 	t.is(input.value, 'abc');
 });
+
+test('text field renders as <textarea> element', (t) => {
+	render(<TextField multiline>{ defaultLabel }</TextField>);
+	t.truthy(screen.getByRole('textbox') as HTMLTextAreaElement);
+});
+
+test('text field renders as <textarea> element within autoSize', (t) => {
+	render(<TextField multiline autoSize>{ defaultLabel }</TextField>);
+	const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+	fireEvent.change(textarea, { key: 'Enter', code: 'Enter' });
+	t.notDeepEqual(textarea.rows, 2);
+});

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -1,68 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
-import {
-	FieldInfo, FieldInfoCoreProps,
-	FieldFeedback, FieldFeedbackCoreProps,
-	FieldAddon,
-} from '../Field';
-import { BaseInput, BaseInputProps } from '../BaseInput';
-
-export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
-
-export interface TextFieldProps
-	extends FieldInfoCoreProps, FieldFeedbackCoreProps, BaseInputProps {
-	/** Text fields can be a limited subset of `<input>` types. */
-	type?: TextFieldType;
-	/** One or more addon that should be included before the `<input>`. */
-	addonBefore?: React.ReactNode;
-	/** One or more addon that should be included after the `<input>`. */
-	addonAfter?: React.ReactNode;
-	/**
-	 * Feedback about the user's current input value. By default, this will
-	 * contain validation errors and the counter, if `maxLength` is specified.
-	 */
-	feedback?: string | React.ReactElement;
-	/** When the character counter should begin showing. */
-	counterStart?: number;
-	/**
-	 * A function that takes the remaining number of characters and the maximum
-	 * number of characters and returns the string or element that will be
-	 * rendered in the character counter slot.
-	 */
-	counter?: false | (({ remaining, max }: {
-		remaining: number;
-		max: number;
-	}) => React.ReactNode);
-	/** The base class name according to BEM conventions. */
-	baseName?: string;
-	/** The className for the TextField's `<input>` element. */
-	inputClass?: string;
-	/** The className for all of the addons (before and after). */
-	addonClass?: string;
-	/** The className for the wrapper that contains the `<input>` & addons. */
-	groupClass?: string;
-	/**
-	 * The className for the TextField's feedback section, which contains the
-	 * error text and character count.
-	 */
-	feedbackClass?: string;
-	/** The className for the TextField's character counter element. */
-	counterClass?: string;
-	/**
-	 * A className that will be applied to the base element when the `<input>`
-	 * is invalid.
-	 */
-	invalidClass?: string;
-	/** A reference to the internal `<input>` element. */
-	inputRef?: React.Ref<HTMLInputElement>;
-	/** Indicates that the indicator should be "required" when `required=true`. */
-	requiredIndicator?: boolean;
-	/** Indicates that the indicator should be "optional" when `required=false`. */
-	optionalIndicator?: boolean;
-	/** Triggered any time the number of characters remaining is updated. */
-	onCount?: (remaining?: number) => void;
-}
+import { FieldInfo, FieldFeedback, FieldAddon } from '../Field';
+import { BaseInput } from '../BaseInput';
+import { TextFieldProps } from './types';
 
 const defaultProps: Partial<TextFieldProps> = {
 	counterStart: 25,
@@ -73,182 +14,211 @@ const defaultProps: Partial<TextFieldProps> = {
 	type: 'text',
 };
 
-export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
-	{
-		// options
-		counterStart = defaultProps.counterStart,
-		validators,
-		validateOnChange,
-		validateOnDOMChange,
-		requiredIndicator,
-		optionalIndicator,
+export const TextField = React.forwardRef<
+HTMLInputElement & HTMLTextAreaElement,
+TextFieldProps
+>(
+	(
+		{
+			// options
+			counterStart = defaultProps.counterStart,
+			validators,
+			validateOnChange,
+			validateOnDOMChange,
+			requiredIndicator,
+			optionalIndicator,
+			multiline,
+			autoSize,
 
-		// anatomy
-		children,
-		description,
-		addonBefore,
-		addonAfter,
-		feedback,
-		errors: errorsProp,
-		counter = defaultProps.counter,
+			// anatomy
+			children,
+			description,
+			addonBefore,
+			addonAfter,
+			feedback,
+			errors: errorsProp,
+			counter = defaultProps.counter,
 
-		// classes
-		baseName = 'nds-field',
-		className = classNames(baseName, `${baseName}--text`),
-		labelClass,
-		descriptionClass,
-		groupClass = classNames(`${baseName}__group`, `${baseName}__group--text`),
-		inputClass = classNames(`${baseName}__input`, `${baseName}__input--text`),
-		addonClass = `${baseName}__addon`,
-		feedbackClass,
-		errorsClass,
-		counterClass = `${baseName}__counter`,
-		invalidClass = `${baseName}--invalid`,
+			// classes
+			baseName = 'nds-field',
+			className = classNames(baseName, `${baseName}--text`),
+			labelClass,
+			descriptionClass,
+			groupClass = classNames(`${baseName}__group`, `${baseName}__group--text`),
+			inputClass = classNames(`${baseName}__input`, `${baseName}__input--text`),
+			addonClass = `${baseName}__addon`,
+			feedbackClass,
+			errorsClass,
+			counterClass = `${baseName}__counter`,
+			invalidClass = `${baseName}--invalid`,
 
-		// ids
-		id: idProp,
-		labelId: labelIdProp,
-		descriptionId: descIdProp,
-		errorsId: errIdProp,
+			// ids
+			id: idProp,
+			labelId: labelIdProp,
+			descriptionId: descIdProp,
+			errorsId: errIdProp,
 
-		// <input> attributes
-		maxLength,
-		required,
-		type = defaultProps.type,
-		value,
+			// <input> attributes
+			maxLength,
+			required,
+			type = defaultProps.type,
+			value,
 
-		// event callbacks
-		onChange,
-		onCount,
-		onDOMChange,
-		onValidate,
+			// event callbacks
+			onChange,
+			onCount,
+			onDOMChange,
+			onValidate,
 
-		// everything else
-		...inputProps
-	}: TextFieldProps, ref,
-) => {
-	const [errors, setErrors] = React.useState(errorsProp);
+			// everything else
+			...inputProps
+		}: TextFieldProps,
+		ref,
+	) => {
+		const [errors, setErrors] = React.useState(errorsProp);
 
-	// ids stored as refs since they shouldn't change between renders
-	const id = React.useRef(idProp || uniqueId(`${baseName}-`));
-	const labelId = React.useRef(labelIdProp || `${id.current}-label`);
-	const descId = React.useRef(descIdProp || `${id.current}-desc`);
-	const errId = React.useRef(errIdProp || `${id.current}-err`);
-	const inputId = React.useRef(`${id.current}-input`);
+		// ids stored as refs since they shouldn't change between renders
+		const id = React.useRef(idProp || uniqueId(`${baseName}-`));
+		const labelId = React.useRef(labelIdProp || `${id.current}-label`);
+		const descId = React.useRef(descIdProp || `${id.current}-desc`);
+		const errId = React.useRef(errIdProp || `${id.current}-err`);
+		const inputId = React.useRef(`${id.current}-input`);
 
-	const getRemaining = React.useCallback((val?: typeof value) => {
-		if (maxLength) {
-			return maxLength - (val || '').toString().length;
-		}
-		return undefined;
-	}, [maxLength]);
-	const [remaining, setRemaining] = React.useState(getRemaining(value));
-	React.useEffect(() => setRemaining(getRemaining(value)), [getRemaining, value]);
+		const getRemaining = React.useCallback(
+			(val?: typeof value) => {
+				if (maxLength) {
+					return maxLength - (val || '').toString().length;
+				}
+				return undefined;
+			},
+			[maxLength],
+		);
+		const [remaining, setRemaining] = React.useState(getRemaining(value));
+		React.useEffect(() => setRemaining(getRemaining(value)), [
+			getRemaining,
+			value,
+		]);
 
-	// treat prop version of errors as source of truth
-	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
+		// treat prop version of errors as source of truth
+		React.useEffect(() => setErrors(errorsProp), [errorsProp]);
 
-	React.useEffect(() => {
-		if (onCount) onCount(remaining);
-	}, [onCount, remaining]);
+		React.useEffect(() => {
+			if (onCount) onCount(remaining);
+		}, [onCount, remaining]);
 
-	const isValid = React.useMemo(() => Boolean(!errors || errors.length === 0), [errors]);
+		const isValid = React.useMemo(
+			() => Boolean(!errors || errors.length === 0),
+			[errors],
+		);
 
-	const validateHandler = (e: string[]): void => {
-		if (onValidate) onValidate(e);
-		setErrors(e);
-	};
+		const validateHandler = (e: string[]): void => {
+			if (onValidate) onValidate(e);
+			setErrors(e);
+		};
 
-	const changeHandler: React.InputHTMLAttributes<HTMLInputElement>['onChange'] = (e) => {
-		if (onChange) onChange(e);
-		else setRemaining(getRemaining(e.target.value));
-	};
+		const changeHandler = (
+			e:
+			| React.ChangeEvent<HTMLInputElement>
+			| React.ChangeEvent<HTMLTextAreaElement>,
+		) => {
+			if (onChange) onChange(e);
+			else setRemaining(getRemaining(e.target.value));
+		};
 
-	const createFieldAddons = (addons: React.ReactNode): React.ReactNode[] | null | undefined => {
-		if (!addons) return null;
-		return React.Children.map(addons, (child) => {
-			if (React.isValidElement(child)) {
-				if (child.type === React.Fragment) {
-					return createFieldAddons(child.props.children);
+		const createFieldAddons = (
+			addons: React.ReactNode,
+		): React.ReactNode[] | null | undefined => {
+			if (!addons) return null;
+			return React.Children.map(addons, (child) => {
+				if (React.isValidElement(child)) {
+					if (child.type === React.Fragment) {
+						return createFieldAddons(child.props.children);
+					}
+				}
+				return <FieldAddon className={addonClass}>{child}</FieldAddon>;
+			});
+		};
+
+		const Counter = React.useMemo(() => {
+			if (!counter) return null;
+			if (
+				maxLength !== undefined
+				&& remaining !== undefined
+				&& counterStart !== undefined
+			) {
+				if (remaining <= counterStart) {
+					return (
+						<div className={counterClass}>
+							{counter({ remaining, max: maxLength })}
+						</div>
+					);
 				}
 			}
-			return <FieldAddon className={addonClass}>{ child }</FieldAddon>;
-		});
-	};
+			return null;
+		}, [counter, counterClass, counterStart, maxLength, remaining]);
 
-	const Counter = React.useMemo(() => {
-		if (!counter) return null;
-		if (maxLength !== undefined && remaining !== undefined && counterStart !== undefined) {
-			if (remaining <= counterStart) {
-				return (
-					<div className={counterClass}>
-						{ counter({ remaining, max: maxLength }) }
-					</div>
-				);
-			}
-		}
-		return null;
-	}, [counter, counterClass, counterStart, maxLength, remaining]);
+		const indicator = React.useMemo(() => {
+			if (requiredIndicator && required) return 'required';
+			if (optionalIndicator && !required) return 'optional';
+			return null;
+		}, [requiredIndicator, optionalIndicator, required]);
 
-	const indicator = React.useMemo(() => {
-		if (requiredIndicator && required) return 'required';
-		if (optionalIndicator && !required) return 'optional';
-		return null;
-	}, [requiredIndicator, optionalIndicator, required]);
-
-	return (
-		<div
-			className={classNames(className, { [invalidClass]: !isValid })}
-			id={id.current}
-		>
-			<FieldInfo
-				htmlFor={inputId.current}
-				label={children}
-				indicator={indicator}
-				labelId={labelId.current}
-				labelClass={labelClass}
-				descriptionClass={descriptionClass}
-				descriptionId={descId.current}
-				description={description}
-			/>
-			<div className={groupClass}>
-				{ createFieldAddons(addonBefore) }
-				<BaseInput
-					ref={ref}
-					value={value}
-					errors={errors}
-					onChange={changeHandler}
-					onDOMChange={onDOMChange}
-					onValidate={validateHandler}
-					id={inputId.current}
-					className={inputClass}
-					aria-describedby={(description) ? descId.current : undefined}
-					aria-invalid={!isValid}
-					aria-errormessage={(!isValid) ? errId.current : undefined}
-					// validation props
-					maxLength={maxLength}
-					required={required}
-					type={type}
-					// BaseInput custom validation props
-					validators={validators}
-					validateOnChange={validateOnChange}
-					validateOnDOMChange={validateOnDOMChange}
-					{...inputProps}
-				/>
-				{ createFieldAddons(addonAfter) }
-			</div>
-			<FieldFeedback
-				className={feedbackClass}
-				errorsId={errId.current}
-				errors={errors}
-				errorsClass={errorsClass}
+		return (
+			<div
+				className={classNames(className, { [invalidClass]: !isValid })}
+				id={id.current}
 			>
-				{ feedback }
-				{ Counter }
-			</FieldFeedback>
-		</div>
-	);
-});
+				<FieldInfo
+					htmlFor={inputId.current}
+					label={children}
+					indicator={indicator}
+					labelId={labelId.current}
+					labelClass={labelClass}
+					descriptionClass={descriptionClass}
+					descriptionId={descId.current}
+					description={description}
+				/>
+				<div className={groupClass}>
+					{!multiline && createFieldAddons(addonBefore)}
+					<BaseInput
+						ref={ref}
+						value={value}
+						errors={errors}
+						multiline={multiline}
+						autoSize={autoSize}
+						onChange={changeHandler}
+						onDOMChange={onDOMChange}
+						onValidate={validateHandler}
+						id={inputId.current}
+						className={inputClass}
+						aria-describedby={description ? descId.current : undefined}
+						aria-invalid={!isValid}
+						aria-errormessage={!isValid ? errId.current : undefined}
+						// validation props
+						maxLength={maxLength}
+						required={required}
+						type={type}
+						// BaseInput custom validation props
+						validators={validators}
+						validateOnChange={validateOnChange}
+						validateOnDOMChange={validateOnDOMChange}
+						{...inputProps}
+					/>
+					{!multiline && createFieldAddons(addonAfter)}
+				</div>
+				<FieldFeedback
+					className={feedbackClass}
+					errorsId={errId.current}
+					errors={errors}
+					errorsClass={errorsClass}
+				>
+					{feedback}
+					{Counter}
+				</FieldFeedback>
+			</div>
+		);
+	},
+);
 
 /**
  * An uncontrolled variant of the `TextField` component. The `value` prop doesn't
@@ -257,7 +227,9 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((
  * values are submitted with native APIs like
  * [HTMLFormElement.submit()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit).
  */
-export const TextFieldUncontrolled = (props: Omit<TextFieldProps, 'value'>): JSX.Element => {
+export const TextFieldUncontrolled = (
+	props: Omit<TextFieldProps, 'value'>,
+): JSX.Element => {
 	const [value, setValue] = React.useState('');
 	return (
 		<TextField

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -184,7 +184,7 @@ export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement
 						<BaseTextArea
 							{...sharedProps}
 							multiline={multiline}
-							autoSize={(multiline) ? autoSize : undefined}
+							autoSize={autoSize}
 						/>
 					)
 					: (

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -141,7 +141,27 @@ export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement
 		return null;
 	}, [requiredIndicator, optionalIndicator, required]);
 
-	const InputComponent = multiline ? BaseTextArea : BaseInput;
+	const sharedProps = {
+		ref,
+		value,
+		errors,
+		onChange: changeHandler,
+		onDOMChange,
+		onValidate: validateHandler,
+		id: inputId.current,
+		className: inputClass,
+		'aria-describedby': (description) ? descId.current : undefined,
+		'aria-invalid': !isValid,
+		'aria-errormessage': (!isValid) ? errId.current : undefined,
+		// validation props
+		maxLength,
+		required,
+		// BaseInput custom validation props
+		validators,
+		validateOnChange,
+		validateOnDOMChange,
+		...inputProps,
+	};
 
 	return (
 		<div
@@ -159,32 +179,21 @@ export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement
 				description={description}
 			/>
 			<div className={groupClass}>
-				{ !multiline && createFieldAddons(addonBefore) }
-				<InputComponent
-					ref={ref}
-					value={value}
-					multiline={multiline}
-					autoSize={autoSize}
-					errors={errors}
-					onChange={changeHandler}
-					onDOMChange={onDOMChange}
-					onValidate={validateHandler}
-					id={inputId.current}
-					className={inputClass}
-					aria-describedby={(description) ? descId.current : undefined}
-					aria-invalid={!isValid}
-					aria-errormessage={(!isValid) ? errId.current : undefined}
-					// validation props
-					maxLength={maxLength}
-					required={required}
-					type={type}
-					// BaseInput custom validation props
-					validators={validators}
-					validateOnChange={validateOnChange}
-					validateOnDOMChange={validateOnDOMChange}
-					{...inputProps}
-				/>
-				{ !multiline && createFieldAddons(addonAfter) }
+				{ (multiline)
+					? (
+						<BaseTextArea
+							{...sharedProps}
+							multiline={multiline}
+							autoSize={(multiline) ? autoSize : undefined}
+						/>
+					)
+					: (
+						<>
+							{ createFieldAddons(addonBefore) }
+							<BaseInput {...sharedProps} type={type} />
+							{ createFieldAddons(addonAfter) }
+						</>
+					) }
 			</div>
 			<FieldFeedback
 				className={feedbackClass}

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -232,7 +232,8 @@ export const TextFieldUncontrolled = (
 	return (
 		<TextField
 			value={value}
-			onChange={(e) => {
+			onChange={(e: React.ChangeEvent<HTMLInputElement> &
+			React.ChangeEvent<HTMLTextAreaElement>) => {
 				setValue(e.target.value);
 				const { onChange } = props;
 				if (onChange) onChange(e);

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -15,208 +15,189 @@ const defaultProps: Partial<TextFieldProps> = {
 	type: 'text',
 };
 
-export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement, TextFieldProps>(
-	(
-		{
-			// options
-			counterStart = defaultProps.counterStart,
-			validators,
-			validateOnChange,
-			validateOnDOMChange,
-			requiredIndicator,
-			optionalIndicator,
-			multiline = false,
-			autoSize = false,
+export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement, TextFieldProps>((
+	{
+		// options
+		counterStart = defaultProps.counterStart,
+		validators,
+		validateOnChange,
+		validateOnDOMChange,
+		requiredIndicator,
+		optionalIndicator,
+		multiline = false,
+		autoSize = false,
 
-			// anatomy
-			children,
-			description,
-			addonBefore,
-			addonAfter,
-			feedback,
-			errors: errorsProp,
-			counter = defaultProps.counter,
+		// anatomy
+		children,
+		description,
+		addonBefore,
+		addonAfter,
+		feedback,
+		errors: errorsProp,
+		counter = defaultProps.counter,
 
-			// classes
-			baseName = 'nds-field',
-			className = classNames(baseName, `${baseName}--text`),
-			labelClass,
-			descriptionClass,
-			groupClass = classNames(`${baseName}__group`, `${baseName}__group--text`),
-			inputClass = classNames(`${baseName}__input`, `${baseName}__input--text`),
-			addonClass = `${baseName}__addon`,
-			feedbackClass,
-			errorsClass,
-			counterClass = `${baseName}__counter`,
-			invalidClass = `${baseName}--invalid`,
+		// classes
+		baseName = 'nds-field',
+		className = classNames(baseName, `${baseName}--text`),
+		labelClass,
+		descriptionClass,
+		groupClass = classNames(`${baseName}__group`, `${baseName}__group--text`),
+		inputClass = classNames(`${baseName}__input`, `${baseName}__input--text`),
+		addonClass = `${baseName}__addon`,
+		feedbackClass,
+		errorsClass,
+		counterClass = `${baseName}__counter`,
+		invalidClass = `${baseName}--invalid`,
 
-			// ids
-			id: idProp,
-			labelId: labelIdProp,
-			descriptionId: descIdProp,
-			errorsId: errIdProp,
+		// ids
+		id: idProp,
+		labelId: labelIdProp,
+		descriptionId: descIdProp,
+		errorsId: errIdProp,
 
-			// <input> attributes
-			maxLength,
-			required,
-			type = defaultProps.type,
-			value,
+		// <input> attributes
+		maxLength,
+		required,
+		type = defaultProps.type,
+		value,
 
-			// event callbacks
-			onChange,
-			onCount,
-			onDOMChange,
-			onValidate,
+		// event callbacks
+		onChange,
+		onCount,
+		onDOMChange,
+		onValidate,
 
-			// everything else
-			...inputProps
-		}: TextFieldProps,
-		ref,
-	) => {
-		const [errors, setErrors] = React.useState(errorsProp);
-		// ids stored as refs since they shouldn't change between renders
-		const id = React.useRef(idProp || uniqueId(`${baseName}-`));
-		const labelId = React.useRef(labelIdProp || `${id.current}-label`);
-		const descId = React.useRef(descIdProp || `${id.current}-desc`);
-		const errId = React.useRef(errIdProp || `${id.current}-err`);
-		const inputId = React.useRef(`${id.current}-input`);
+		// everything else
+		...inputProps
+	}: TextFieldProps, ref,
+) => {
+	const [errors, setErrors] = React.useState(errorsProp);
 
-		const getRemaining = React.useCallback(
-			(val?: typeof value) => {
-				if (maxLength) {
-					return maxLength - (val || '').toString().length;
-				}
-				return undefined;
-			},
-			[maxLength],
-		);
-		const [remaining, setRemaining] = React.useState(getRemaining(value));
-		React.useEffect(() => setRemaining(getRemaining(value)), [
-			getRemaining,
-			value,
-		]);
+	// ids stored as refs since they shouldn't change between renders
+	const id = React.useRef(idProp || uniqueId(`${baseName}-`));
+	const labelId = React.useRef(labelIdProp || `${id.current}-label`);
+	const descId = React.useRef(descIdProp || `${id.current}-desc`);
+	const errId = React.useRef(errIdProp || `${id.current}-err`);
+	const inputId = React.useRef(`${id.current}-input`);
 
-		// treat prop version of errors as source of truth
-		React.useEffect(() => setErrors(errorsProp), [errorsProp]);
+	const getRemaining = React.useCallback((val?: typeof value) => {
+		if (maxLength) {
+			return maxLength - (val || '').toString().length;
+		}
+		return undefined;
+	}, [maxLength]);
+	const [remaining, setRemaining] = React.useState(getRemaining(value));
+	React.useEffect(() => setRemaining(getRemaining(value)), [getRemaining, value]);
 
-		React.useEffect(() => {
-			if (onCount) onCount(remaining);
-		}, [onCount, remaining]);
+	// treat prop version of errors as source of truth
+	React.useEffect(() => setErrors(errorsProp), [errorsProp]);
 
-		const isValid = React.useMemo(
-			() => Boolean(!errors || errors.length === 0),
-			[errors],
-		);
+	React.useEffect(() => {
+		if (onCount) onCount(remaining);
+	}, [onCount, remaining]);
 
-		const validateHandler = (e: string[]): void => {
-			if (onValidate) onValidate(e);
-			setErrors(e);
-		};
+	const isValid = React.useMemo(() => Boolean(!errors || errors.length === 0), [errors]);
 
-		const changeHandler = (
-			e: React.ChangeEvent<HTMLInputElement>
-			& React.ChangeEvent<HTMLTextAreaElement>,
-		) => {
-			if (onChange) onChange(e);
-			else setRemaining(getRemaining(e.target.value));
-		};
+	const validateHandler = (e: string[]): void => {
+		if (onValidate) onValidate(e);
+		setErrors(e);
+	};
 
-		const createFieldAddons = (
-			addons: React.ReactNode,
-		): React.ReactNode[] | null | undefined => {
-			if (!addons) return null;
-			return React.Children.map(addons, (child) => {
-				if (React.isValidElement(child)) {
-					if (child.type === React.Fragment) {
-						return createFieldAddons(child.props.children);
-					}
-				}
-				return <FieldAddon className={addonClass}>{child}</FieldAddon>;
-			});
-		};
+	const changeHandler = (e: React.ChangeEvent<HTMLInputElement>
+	& React.ChangeEvent<HTMLTextAreaElement>) => {
+		if (onChange) onChange(e);
+		else setRemaining(getRemaining(e.target.value));
+	};
 
-		const Counter = React.useMemo(() => {
-			if (!counter) return null;
-			if (
-				maxLength !== undefined
-				&& remaining !== undefined
-				&& counterStart !== undefined
-			) {
-				if (remaining <= counterStart) {
-					return (
-						<div className={counterClass}>
-							{counter({ remaining, max: maxLength })}
-						</div>
-					);
+	const createFieldAddons = (addons: React.ReactNode): React.ReactNode[] | null | undefined => {
+		if (!addons) return null;
+		return React.Children.map(addons, (child) => {
+			if (React.isValidElement(child)) {
+				if (child.type === React.Fragment) {
+					return createFieldAddons(child.props.children);
 				}
 			}
-			return null;
-		}, [counter, counterClass, counterStart, maxLength, remaining]);
+			return <FieldAddon className={addonClass}>{ child }</FieldAddon>;
+		});
+	};
 
-		const indicator = React.useMemo(() => {
-			if (requiredIndicator && required) return 'required';
-			if (optionalIndicator && !required) return 'optional';
-			return null;
-		}, [requiredIndicator, optionalIndicator, required]);
+	const Counter = React.useMemo(() => {
+		if (!counter) return null;
+		if (maxLength !== undefined && remaining !== undefined && counterStart !== undefined) {
+			if (remaining <= counterStart) {
+				return (
+					<div className={counterClass}>
+						{ counter({ remaining, max: maxLength }) }
+					</div>
+				);
+			}
+		}
+		return null;
+	}, [counter, counterClass, counterStart, maxLength, remaining]);
 
-		const InputComponent = multiline ? BaseTextArea : BaseInput;
+	const indicator = React.useMemo(() => {
+		if (requiredIndicator && required) return 'required';
+		if (optionalIndicator && !required) return 'optional';
+		return null;
+	}, [requiredIndicator, optionalIndicator, required]);
 
-		return (
-			<div
-				className={classNames(className, { [invalidClass]: !isValid })}
-				id={id.current}
-			>
-				<FieldInfo
-					htmlFor={inputId.current}
-					label={children}
-					indicator={indicator}
-					labelId={labelId.current}
-					labelClass={labelClass}
-					descriptionClass={descriptionClass}
-					descriptionId={descId.current}
-					description={description}
-				/>
-				<div className={groupClass}>
-					{!multiline && createFieldAddons(addonBefore)}
-					<InputComponent
-						ref={ref}
-						value={value}
-						multiline={multiline}
-						autoSize={autoSize}
-						errors={errors}
-						onChange={changeHandler}
-						onDOMChange={onDOMChange}
-						onValidate={validateHandler}
-						id={inputId.current}
-						className={inputClass}
-						aria-describedby={description ? descId.current : undefined}
-						aria-invalid={!isValid}
-						aria-errormessage={!isValid ? errId.current : undefined}
-						// validation props
-						maxLength={maxLength}
-						required={required}
-						type={type}
-						// BaseInput custom validation props
-						validators={validators}
-						validateOnChange={validateOnChange}
-						validateOnDOMChange={validateOnDOMChange}
-						{...inputProps}
-					/>
-					{!multiline && createFieldAddons(addonAfter)}
-				</div>
-				<FieldFeedback
-					className={feedbackClass}
-					errorsId={errId.current}
+	const InputComponent = multiline ? BaseTextArea : BaseInput;
+
+	return (
+		<div
+			className={classNames(className, { [invalidClass]: !isValid })}
+			id={id.current}
+		>
+			<FieldInfo
+				htmlFor={inputId.current}
+				label={children}
+				indicator={indicator}
+				labelId={labelId.current}
+				labelClass={labelClass}
+				descriptionClass={descriptionClass}
+				descriptionId={descId.current}
+				description={description}
+			/>
+			<div className={groupClass}>
+				{ !multiline && createFieldAddons(addonBefore) }
+				<InputComponent
+					ref={ref}
+					value={value}
+					multiline={multiline}
+					autoSize={autoSize}
 					errors={errors}
-					errorsClass={errorsClass}
-				>
-					{feedback}
-					{Counter}
-				</FieldFeedback>
+					onChange={changeHandler}
+					onDOMChange={onDOMChange}
+					onValidate={validateHandler}
+					id={inputId.current}
+					className={inputClass}
+					aria-describedby={(description) ? descId.current : undefined}
+					aria-invalid={!isValid}
+					aria-errormessage={(!isValid) ? errId.current : undefined}
+					// validation props
+					maxLength={maxLength}
+					required={required}
+					type={type}
+					// BaseInput custom validation props
+					validators={validators}
+					validateOnChange={validateOnChange}
+					validateOnDOMChange={validateOnDOMChange}
+					{...inputProps}
+				/>
+				{ !multiline && createFieldAddons(addonAfter) }
 			</div>
-		);
-	},
-);
+			<FieldFeedback
+				className={feedbackClass}
+				errorsId={errId.current}
+				errors={errors}
+				errorsClass={errorsClass}
+			>
+				{ feedback }
+				{ Counter }
+			</FieldFeedback>
+		</div>
+	);
+});
 
 /**
  * An uncontrolled variant of the `TextField` component. The `value` prop doesn't
@@ -225,9 +206,7 @@ export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement
  * values are submitted with native APIs like
  * [HTMLFormElement.submit()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit).
  */
-export const TextFieldUncontrolled = (
-	props: Omit<TextFieldProps, 'value'>,
-): JSX.Element => {
+export const TextFieldUncontrolled = (props: Omit<TextFieldProps, 'value'>): JSX.Element => {
 	const [value, setValue] = React.useState('');
 	return (
 		<TextField

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
 import { FieldInfo, FieldFeedback, FieldAddon } from '../Field';
 import { BaseInput } from '../BaseInput';
+import { BaseTextArea } from '../BaseTextArea';
 import { TextFieldProps } from './types';
 
 const defaultProps: Partial<TextFieldProps> = {
@@ -14,10 +15,7 @@ const defaultProps: Partial<TextFieldProps> = {
 	type: 'text',
 };
 
-export const TextField = React.forwardRef<
-HTMLInputElement & HTMLTextAreaElement,
-TextFieldProps
->(
+export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement, TextFieldProps>(
 	(
 		{
 			// options
@@ -27,8 +25,8 @@ TextFieldProps
 			validateOnDOMChange,
 			requiredIndicator,
 			optionalIndicator,
-			multiline,
-			autoSize,
+			multiline = false,
+			autoSize = false,
 
 			// anatomy
 			children,
@@ -76,7 +74,6 @@ TextFieldProps
 		ref,
 	) => {
 		const [errors, setErrors] = React.useState(errorsProp);
-
 		// ids stored as refs since they shouldn't change between renders
 		const id = React.useRef(idProp || uniqueId(`${baseName}-`));
 		const labelId = React.useRef(labelIdProp || `${id.current}-label`);
@@ -117,9 +114,8 @@ TextFieldProps
 		};
 
 		const changeHandler = (
-			e:
-			| React.ChangeEvent<HTMLInputElement>
-			| React.ChangeEvent<HTMLTextAreaElement>,
+			e: React.ChangeEvent<HTMLInputElement>
+			& React.ChangeEvent<HTMLTextAreaElement>,
 		) => {
 			if (onChange) onChange(e);
 			else setRemaining(getRemaining(e.target.value));
@@ -163,6 +159,8 @@ TextFieldProps
 			return null;
 		}, [requiredIndicator, optionalIndicator, required]);
 
+		const InputComponent = multiline ? BaseTextArea : BaseInput;
+
 		return (
 			<div
 				className={classNames(className, { [invalidClass]: !isValid })}
@@ -180,12 +178,12 @@ TextFieldProps
 				/>
 				<div className={groupClass}>
 					{!multiline && createFieldAddons(addonBefore)}
-					<BaseInput
+					<InputComponent
 						ref={ref}
 						value={value}
-						errors={errors}
 						multiline={multiline}
 						autoSize={autoSize}
+						errors={errors}
 						onChange={changeHandler}
 						onDOMChange={onDOMChange}
 						onValidate={validateHandler}

--- a/packages/react/src/components/TextField/types.ts
+++ b/packages/react/src/components/TextField/types.ts
@@ -5,7 +5,7 @@ import { FieldFeedbackCoreProps, FieldInfoCoreProps } from '../Field';
 
 export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
-export interface TextFieldBaseProps
+export interface BaseTextFieldProps
 	extends FieldInfoCoreProps, FieldFeedbackCoreProps, BaseInputProps {
 	/** Text fields can be a limited subset of `<input>` types. */
 	type?: TextFieldType;
@@ -60,10 +60,10 @@ export interface TextFieldBaseProps
 	/** Allow for multiple lines of input */
 	multiline?: boolean | number;
 	/**
-   * If `true` increase the height of textarea automatically
+	 * If `true` increase the height of textarea automatically
 	 * only works when multiline prop it's `enable`
-   */
+	 */
 	autoSize?: boolean;
 }
 
-export type TextFieldProps = TextFieldBaseProps & BaseTextAreaProps;
+export type TextFieldProps = BaseTextFieldProps & BaseTextAreaProps;

--- a/packages/react/src/components/TextField/types.ts
+++ b/packages/react/src/components/TextField/types.ts
@@ -67,4 +67,22 @@ export interface TextFieldProps
    * @default false
    */
 	autoSize?: boolean;
+	/**
+   * Number of rows for textarea
+	 * only works when multiline prop it's `true`
+   * @default 1
+   */
+	rows?: number;
+	/**
+   * Number of minRows for textarea
+	 * only works when multiline prop it's `true`
+   * @default 1
+   */
+	minRows?: number;
+	/**
+   * Number of maxRows for textarea
+	 * only works when multiline prop it's `true`
+   * @default Infinity
+   */
+	maxRows?: number;
 }

--- a/packages/react/src/components/TextField/types.ts
+++ b/packages/react/src/components/TextField/types.ts
@@ -1,0 +1,70 @@
+import React from 'react';
+import { BaseInputProps } from '../BaseInput/types';
+import { FieldFeedbackCoreProps, FieldInfoCoreProps } from '../Field';
+
+export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
+
+export interface TextFieldProps
+	extends FieldInfoCoreProps, FieldFeedbackCoreProps, BaseInputProps {
+	/** Text fields can be a limited subset of `<input>` types. */
+	type?: TextFieldType;
+	/** One or more addon that should be included before the `<input>`. */
+	addonBefore?: React.ReactNode;
+	/** One or more addon that should be included after the `<input>`. */
+	addonAfter?: React.ReactNode;
+	/**
+	 * Feedback about the user's current input value. By default, this will
+	 * contain validation errors and the counter, if `maxLength` is specified.
+	 */
+	feedback?: string | React.ReactElement;
+	/** When the character counter should begin showing. */
+	counterStart?: number;
+	/**
+	 * A function that takes the remaining number of characters and the maximum
+	 * number of characters and returns the string or element that will be
+	 * rendered in the character counter slot.
+	 */
+	counter?: false | (({ remaining, max }: {
+		remaining: number;
+		max: number;
+	}) => React.ReactNode);
+	/** The base class name according to BEM conventions. */
+	baseName?: string;
+	/** The className for the TextField's `<input>` element. */
+	inputClass?: string;
+	/** The className for all of the addons (before and after). */
+	addonClass?: string;
+	/** The className for the wrapper that contains the `<input>` & addons. */
+	groupClass?: string;
+	/**
+	 * The className for the TextField's feedback section, which contains the
+	 * error text and character count.
+	 */
+	feedbackClass?: string;
+	/** The className for the TextField's character counter element. */
+	counterClass?: string;
+	/**
+	 * A className that will be applied to the base element when the `<input>`
+	 * is invalid.
+	 */
+	invalidClass?: string;
+	/** A reference to the internal `<input>` element. */
+	inputRef?: React.Ref<HTMLInputElement | HTMLTextAreaElement>;
+	/** Indicates that the indicator should be "required" when `required=true`. */
+	requiredIndicator?: boolean;
+	/** Indicates that the indicator should be "optional" when `required=false`. */
+	optionalIndicator?: boolean;
+	/** Triggered any time the number of characters remaining is updated. */
+	onCount?: (remaining?: number) => void;
+	/**
+	 * attribute to render TextArea always
+	 * @default false
+	 */
+	multiline?: boolean;
+	/**
+   * If `true` increase the height of textarea automatically
+	 * only works when multiline prop it's `true`
+   * @default false
+   */
+	autoSize?: boolean;
+}

--- a/packages/react/src/components/TextField/types.ts
+++ b/packages/react/src/components/TextField/types.ts
@@ -1,10 +1,11 @@
 import React from 'react';
 import { BaseInputProps } from '../BaseInput/types';
+import { BaseTextAreaProps } from '../BaseTextArea/types';
 import { FieldFeedbackCoreProps, FieldInfoCoreProps } from '../Field';
 
 export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
-export interface TextFieldProps
+export interface TextFieldBaseProps
 	extends FieldInfoCoreProps, FieldFeedbackCoreProps, BaseInputProps {
 	/** Text fields can be a limited subset of `<input>` types. */
 	type?: TextFieldType;
@@ -64,3 +65,5 @@ export interface TextFieldProps
    */
 	autoSize?: boolean;
 }
+
+export type TextFieldProps = TextFieldBaseProps & BaseTextAreaProps;

--- a/packages/react/src/components/TextField/types.ts
+++ b/packages/react/src/components/TextField/types.ts
@@ -56,33 +56,11 @@ export interface TextFieldProps
 	optionalIndicator?: boolean;
 	/** Triggered any time the number of characters remaining is updated. */
 	onCount?: (remaining?: number) => void;
-	/**
-	 * attribute to render TextArea always
-	 * @default false
-	 */
-	multiline?: boolean;
+	/** Allow for multiple lines of input */
+	multiline?: boolean | number;
 	/**
    * If `true` increase the height of textarea automatically
-	 * only works when multiline prop it's `true`
-   * @default false
+	 * only works when multiline prop it's `enable`
    */
 	autoSize?: boolean;
-	/**
-   * Number of rows for textarea
-	 * only works when multiline prop it's `true`
-   * @default 1
-   */
-	rows?: number;
-	/**
-   * Number of minRows for textarea
-	 * only works when multiline prop it's `true`
-   * @default 1
-   */
-	minRows?: number;
-	/**
-   * Number of maxRows for textarea
-	 * only works when multiline prop it's `true`
-   * @default Infinity
-   */
-	maxRows?: number;
 }


### PR DESCRIPTION
Multiline component `multiline` prop approach in `TextField` component

- `multiline` boolean property was added to the `Textfield` API, to render a textarea.
- The `TextField` component with multiline property, allows to have the same behaviors of the `TextField` component such as error handling, number of characters, and attributes of the textarea element.
- `afterAddon` and `beforeAddon` are not rendered if the component is multiline.
- Boolean property `autoSize` added to the TextField API, allows the component to grow dynamically as long as the `multiline` and `autoSize` property are `active`.
- Examples of `multiline` component were added to the `storybook`