### PR TITLE
fix: wrap disclosure's summary in div [NDS-93]

### DIFF
--- a/packages/react/src/components/BaseSummary/index.tsx
+++ b/packages/react/src/components/BaseSummary/index.tsx
@@ -19,7 +19,7 @@ export const BaseSummary = React.forwardRef<HTMLElement, BaseSummaryProps>(({
 	<summary ref={ref} {...attributes}>
 		{/*
 			This div is a temporary fix for safari 14
-			https://bugs.webkit.org/show_bug.cgi?id=190065 - sumamry can't be flexbox
+			https://bugs.webkit.org/show_bug.cgi?id=190065 - summary can't be flex box
 		*/}
 		<div style={{ display: 'flex', width: '100%' }}>
 			{ markerPosition === 'left' && marker }

--- a/packages/react/src/components/BaseSummary/index.tsx
+++ b/packages/react/src/components/BaseSummary/index.tsx
@@ -16,8 +16,12 @@ export const BaseSummary = React.forwardRef<HTMLElement, BaseSummaryProps>(({
 	children,
 	...attributes
 }: BaseSummaryProps, ref) => (
-	<summary ref={ref}>
-		<div {...attributes}>
+	<summary ref={ref} {...attributes}>
+		{/*
+			This div is a temporary fix for safari 14
+			https://bugs.webkit.org/show_bug.cgi?id=190065 - sumamry can't be flexbox
+		*/}
+		<div style={{ display: 'flex', width: '100%' }}>
 			{ markerPosition === 'left' && marker }
 			{ children }
 			{ markerPosition === 'right' && marker }

--- a/packages/react/src/components/BaseSummary/index.tsx
+++ b/packages/react/src/components/BaseSummary/index.tsx
@@ -16,9 +16,11 @@ export const BaseSummary = React.forwardRef<HTMLElement, BaseSummaryProps>(({
 	children,
 	...attributes
 }: BaseSummaryProps, ref) => (
-	<summary ref={ref} {...attributes}>
-		{ markerPosition === 'left' && marker }
-		{ children }
-		{ markerPosition === 'right' && marker }
+	<summary ref={ref}>
+		<div {...attributes}>
+			{ markerPosition === 'left' && marker }
+			{ children }
+			{ markerPosition === 'right' && marker }
+		</div>
 	</summary>
 ));


### PR DESCRIPTION
Workaround based on https://github.com/philipwalton/flexbugs#flexbug-9 to allow `<summary>` element to be a flexbox in safari

Tested in Safari 14.1.1:
![image](https://user-images.githubusercontent.com/47323512/128086986-49738471-1175-4e78-96df-57db5964ebb3.png)

https://pr-187.d2xq18ppjtz6lz.amplifyapp.com/storybook/?path=/story/disclosure--panel