### PR TITLE
Add codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 0.05%
+        base: auto
+comment:
+  # wait for all jobs to complete before reporting to help avoid premature failures
+  # https://docs.codecov.com/docs/unexpected-coverage-changes
+  after_n_builds: 8


### PR DESCRIPTION
In recent PRs and commits, we've been seeing some odd [codecov/patch](https://docs.codecov.com/docs/commit-status#patch-status) issues where code coverage dropped by some tiny amount even when no covered lines were changed. From what I can tell, this can be a very difficult thing to track down because some element of our environment is non-deterministic. Rather than tracking that down (we may not even be able to control it), this configures codecov to have a higher tolerance to account for those kinds of changes, as well as waiting to comment in PRs until all the jobs have completed.

Reference: https://docs.codecov.com/docs/unexpected-coverage-changes