### PR TITLE
Button Component Updates: Disable Cursor NDS-29

### DIFF
--- a/packages/core/src/components/button/index.scss
+++ b/packages/core/src/components/button/index.scss
@@ -163,6 +163,11 @@
 	}
 }
 
+@mixin cursor-disabled {
+	pointer-events: none;
+	cursor: not-allowed;
+}
+
 @mixin style {
 	@include util.declare('button') {
 		.nds-button {
@@ -183,6 +188,10 @@
 
 		.nds-button--icon-only {
 			@include icon-only;
+		}
+
+		.nds-button--cursor-disabled {
+			@include cursor-disabled;
 		}
 
 		.nds-button__icon {

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -1,58 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useForwardedRef } from '../../utilities';
-import { BaseButton, BaseButtonProps } from '../BaseButton';
-import { Icon, IconVariant, SVGIcon } from '../Icon';
+import { BaseButton } from '../BaseButton';
+import { Icon } from '../Icon';
 import { Tooltip } from '../Tooltip';
-import { TooltipCoreProps } from '../Tooltip/types';
 import { LiveRegion, useContentMonitor } from '../LiveRegion';
-import { AllColors } from '../../utilities/color';
 import { BUTTON_NO_NAME } from './errors';
-
-export type ButtonVariant = 'solid' | 'outline' | 'ghost';
-
-export interface ButtonProps extends BaseButtonProps {
-	/**
-	 * Button `children` are required because they are used to provide an accessible
-	 * label for the button. When rendering with `iconOnly`, the children will be
-	 * rendered as an accessible `Tooltip` that labels the button.
-	 */
-	children: BaseButtonProps['children'];
-	/** Button variant conveys the button's level of visual emphasis. */
-	variant?: ButtonVariant;
-	/** An icon to include in the button. */
-	icon?: IconVariant | SVGIcon;
-	/**
-	 * Indicates whether the icon should be to the right of the text. By default,
-	 * the icon is to the left of the text.
-	 */
-	iconRight?: boolean;
-	/**
-	 * Indicates whether the button's contents should only be the icon. When
-	 * `true`, the button's text is still required but will be used as the icon's
-	 * `aria-label`. If no `icon` is specified, this prop has no effect.
-	 */
-	iconOnly?: boolean;
-	/**
-	 * The button's color, restricted to [design system colors](https://wwnorton.github.io/design-system/docs/color),
-	 * excluding `disabled` (prefer the `disabled` prop). Note that an `undefined`
-	 * color will result in the "primary" color being used.
-	 */
-	color?: Exclude<AllColors, 'disabled'>;
-	/** A reference to the inner `<button>` element. */
-	buttonRef?: React.Ref<HTMLButtonElement>;
-	/** The base class name according to BEM conventions. */
-	baseName?: string;
-	/** The className for the Button's icon, if one exists. */
-	iconClass?: string;
-	/** The className for the Button's text, which will be placed in a `<span>` */
-	textClass?: string;
-	/**
-	 * Tooltip props that should be included when the button's children are
-	 * rendered as a tooltip.
-	 */
-	tooltipProps?: Partial<TooltipCoreProps>;
-}
+import { ButtonProps } from './types';
 
 /** A button allows a user to perform an action. */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((
@@ -68,6 +22,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((
 		textClass = `${baseName}__text`,
 		className,
 		children,
+		loading = false,
+		disabled,
 		'aria-label': ariaLabel,
 		'aria-labelledby': ariaLabelledBy,
 		...props
@@ -104,6 +60,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((
 			[`${baseName}--ghost`]: variant === 'ghost',
 			[`${baseName}--icon-only`]: icon && iconOnly,
 			[`${baseName}--${color}`]: color !== undefined,
+			[`${baseName}--cursor-disabled`]: (loading || disabled),
 		},
 		baseName,
 		className,

--- a/packages/react/src/components/Button/IconButton.tsx
+++ b/packages/react/src/components/Button/IconButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, ButtonProps } from './Button';
+import { Button } from './Button';
+import { ButtonProps } from './types';
 
 export type IconButtonProps = Omit<ButtonProps, 'iconOnly' | 'iconRight'>;
 

--- a/packages/react/src/components/Button/index.stories.tsx
+++ b/packages/react/src/components/Button/index.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Story } from '@storybook/react';
-import { Button, IconButton, ButtonProps } from '.';
+import { Button, IconButton } from '.';
 import { IconButtonProps } from './IconButton';
 import { IconOptions } from '../Icon';
+import { ButtonProps } from './types';
 
 export default {
 	title: 'Button',

--- a/packages/react/src/components/Button/types.ts
+++ b/packages/react/src/components/Button/types.ts
@@ -1,0 +1,51 @@
+import { AllColors } from '../../utilities/color';
+import { BaseButtonProps } from '../BaseButton';
+import { IconVariant, SVGIcon } from '../Icon';
+import { TooltipCoreProps } from '../Tooltip/types';
+
+export type ButtonVariant = 'solid' | 'outline' | 'ghost';
+
+export interface ButtonProps extends BaseButtonProps {
+	/**
+	 * Button `children` are required because they are used to provide an accessible
+	 * label for the button. When rendering with `iconOnly`, the children will be
+	 * rendered as an accessible `Tooltip` that labels the button.
+	 */
+	children: BaseButtonProps['children'];
+	/** Button variant conveys the button's level of visual emphasis. */
+	variant?: ButtonVariant;
+	/** An icon to include in the button. */
+	icon?: IconVariant | SVGIcon;
+	/**
+	 * Indicates whether the icon should be to the right of the text. By default,
+	 * the icon is to the left of the text.
+	 */
+	iconRight?: boolean;
+	/**
+	 * Indicates whether the button's contents should only be the icon. When
+	 * `true`, the button's text is still required but will be used as the icon's
+	 * `aria-label`. If no `icon` is specified, this prop has no effect.
+	 */
+	iconOnly?: boolean;
+	/**
+	 * The button's color, restricted to [design system colors](https://wwnorton.github.io/design-system/docs/color),
+	 * excluding `disabled` (prefer the `disabled` prop). Note that an `undefined`
+	 * color will result in the "primary" color being used.
+	 */
+	color?: Exclude<AllColors, 'disabled'>;
+	/** A reference to the inner `<button>` element. */
+	buttonRef?: React.Ref<HTMLButtonElement>;
+	/** The base class name according to BEM conventions. */
+	baseName?: string;
+	/** The className for the Button's icon, if one exists. */
+	iconClass?: string;
+	/** The className for the Button's text, which will be placed in a `<span>` */
+	textClass?: string;
+	/**
+	 * Tooltip props that should be included when the button's children are
+	 * rendered as a tooltip.
+	 */
+	tooltipProps?: Partial<TooltipCoreProps>;
+	/** Set the loading status of button */
+	loading?: boolean;
+}

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -5,7 +5,8 @@ import uniqueId from 'lodash/uniqueId';
 import { getFocusable } from './focusable';
 import { canUseDOM } from '../../utilities';
 import { BaseDialog, BaseDialogProps } from '../BaseDialog';
-import { IconButton, ButtonProps } from '../Button';
+import { IconButton } from '../Button';
+import { ButtonProps } from '../Button/types';
 
 export type ModalAnatomy =
 	| 'portal'

--- a/packages/react/src/components/Popover/types.ts
+++ b/packages/react/src/components/Popover/types.ts
@@ -1,6 +1,6 @@
-import { ButtonProps } from '../Button';
 import { PopperProps } from '../Popper';
 import { UsePopperTriggersProps } from '../../utilities';
+import { ButtonProps } from '../Button/types';
 
 type PopperInherited = Pick<PopperProps,
 | 'isOpen'

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
-import { Button, ButtonProps } from '../Button';
+import { Button } from '../Button';
 import { FieldInfo, FieldInfoCoreProps } from '../Field';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { TooltipCoreProps } from '../Tooltip/types';
 import { useForwardedRef } from '../../utilities';
+import { ButtonProps } from '../Button/types';
 
 export interface SwitchProps extends FieldInfoCoreProps, Omit<ButtonProps, 'children'> {
 	/** The name of the Switch. Required. */

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -10,10 +10,11 @@ import {
 import {
 	TextField, TextFieldUncontrolled,
 } from '.';
-import { Button, ButtonProps } from '../Button';
+import { Button } from '../Button';
 import { Icon, IconProps } from '../Icon';
 import { useValidation } from '../../utilities';
 import { TextFieldProps, TextFieldType } from './types';
+import { ButtonProps } from '../Button/types';
 
 export default {
 	title: 'Text Field',


### PR DESCRIPTION
**What does this PR do?**

- `ButtonProps` were moved to types.ts.
- `ButtonProps` imports were updated.
- `cursor-disabled` mixin was added for button.
- `cursor-disabled` modifier is added to `Button` when it's loading or disabled.


**Screenshot**

<img width="1440" alt="Captura de Pantalla 2021-09-02 a la(s) 8 43 39 a  m" src="https://user-images.githubusercontent.com/85630200/131855607-e6d70f43-0345-435c-9b37-f23b97d6da80.png">
