### PR TITLE
NDS-237: Modal visual design spacing is broken

### DIFF
--- a/packages/core/src/spacing/index.scss
+++ b/packages/core/src/spacing/index.scss
@@ -92,7 +92,7 @@ $-spacer-roles: (
 		token: 'spacing-3',
 	),
 	(
-		keys: (4, '1rem', '16px', 'block-base', 'cell-base','popover-x','popover-y'),
+		keys: (4, '1rem', '16px', 'block-base', 'cell-base','popover-x','popover-y', 'modal-y'),
 		token: 'spacing-4',
 	),
 	(
@@ -100,7 +100,7 @@ $-spacer-roles: (
 		token: 'spacing-5',
 	),
 	(
-		keys: (6, '1.5rem', '24px', 'disclosure-x', 'callout-x', 'callout-y','modal-y'),
+		keys: (6, '1.5rem', '24px', 'disclosure-x', 'callout-x', 'callout-y'),
 		token: 'spacing-6',
 	),
 	(


### PR DESCRIPTION
Spacing in title bar and action bar were too big. Now matches what's on Zeplin.

Change `padding-y` for modal from `1.5rem => spacing-6` to `1rem => spacing-4`
