### PR TITLE
NDS-275: Fix Disclosure opens/closes without animation and then it won't open at all

### DIFF
--- a/packages/core/src/motion/index.scss
+++ b/packages/core/src/motion/index.scss
@@ -27,13 +27,17 @@
 	$prop-list: if(meta.type-of($properties) == 'string', ($properties), $properties);
 
 	@each $property in $prop-list {
-		$full-transition: list.join($full-transition, #{$property} -scale($duration) #{$easing}, $separator: comma);
+		$full-transition: list.join(
+			$full-transition,
+			#{$property scale-duration($duration) $easing},
+			$separator: comma
+		);
 	}
 
 	@return $full-transition;
 }
 
-@function -scale($duration) {
+@function scale-duration($duration) {
 	@return calc(#{$duration} * var(--nds-duration-scalar));
 }
 


### PR DESCRIPTION
Reverted automatic linter fix from 9ff6abed017250b8783a7c175face91b9cfda42b (PR https://github.com/wwnorton/design-system/pull/228)

The stylelint rule `scss/operator-no-unspaced` was giving a false positive due to a function called `-scale` starting with the `-` symbol and reading it as an operator. The auto fix screwed up the full-transition formula in the `transition` function

Simply renamed the `-scale` function to `scale-duration` to prevent lint errors and reverted the change in the `transition` formula