### PR TITLE
Ship dependent types NDS-320

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17341,7 +17341,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
       "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -49271,7 +49270,7 @@
     },
     "packages/core": {
       "name": "@wwnds/core",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@material/circular-progress": "^13.0.0",
@@ -49289,11 +49288,12 @@
     },
     "packages/react": {
       "name": "@wwnds/react",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@material/linear-progress": "^13.0.0",
         "@popperjs/core": "^2.11.5",
+        "@types/react-transition-group": "^4.4.4",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "react-fast-compare": "^3.2.0",
@@ -49303,7 +49303,6 @@
       },
       "devDependencies": {
         "@types/react-is": "^17.0.3",
-        "@types/react-transition-group": "^4.4.4",
         "react-router-dom": "^6.2.1"
       },
       "peerDependencies": {
@@ -49347,7 +49346,7 @@
       }
     },
     "website": {
-      "version": "1.3.2",
+      "version": "1.4.0",
       "bundleDependencies": [
         "@docusaurus/theme-common",
         "clsx"
@@ -49358,8 +49357,8 @@
         "@docusaurus/plugin-pwa": "2.0.0-beta.14",
         "@docusaurus/preset-classic": "2.0.0-beta.14",
         "@docusaurus/theme-live-codeblock": "2.0.0-beta.14",
-        "@wwnds/core": "^1.3.2",
-        "@wwnds/react": "^1.3.2",
+        "@wwnds/core": "^1.4.0",
+        "@wwnds/react": "^1.4.0",
         "colorable": "^1.0.5",
         "docusaurus-lunr-search": "^2.1.15",
         "react": "^17.0.1",
@@ -62961,7 +62960,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
       "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -87151,8 +87149,8 @@
         "@docusaurus/preset-classic": "2.0.0-beta.14",
         "@docusaurus/theme-live-codeblock": "2.0.0-beta.14",
         "@storybook/react-docgen-typescript-plugin": "^1.0.1",
-        "@wwnds/core": "^1.3.2",
-        "@wwnds/react": "^1.3.2",
+        "@wwnds/core": "^1.4.0",
+        "@wwnds/react": "^1.4.0",
         "colorable": "^1.0.5",
         "docusaurus-lunr-search": "^2.1.15",
         "react": "^17.0.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@material/linear-progress": "^13.0.0",
     "@popperjs/core": "^2.11.5",
+    "@types/react-transition-group": "^4.4.4",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "react-fast-compare": "^3.2.0",
@@ -51,7 +52,6 @@
   },
   "devDependencies": {
     "@types/react-is": "^17.0.3",
-    "@types/react-transition-group": "^4.4.4",
     "react-router-dom": "^6.2.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Popper's types extend react-transition-group's types, so we need to ship those types.