### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -44,7 +44,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -71,7 +71,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -92,7 +92,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -113,7 +113,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -134,7 +134,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -159,7 +159,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Test 🧪
         run: npm run coverage
       - name: Codecov ☂
-        uses: codecov/codecov-action@v2.0.2
+        uses: codecov/codecov-action@v3
         if: ${{ matrix.node == env.NODE_VERSION }}
         with:
           directory: coverage

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Update npm
         run: npm i -g npm@${{ env.NPM_VERSION }}
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
This is a manual update for the changes proposed by #284 & #285, but fixing actions versions at the major version number so dependabot won't open a PR for every in-range version change (in other words, when they release a minor or patch update).