### PR TITLE
Prevent document shifting when modal opens NDS-334

### DIFF
--- a/packages/react/src/components/Modal/index.test.tsx
+++ b/packages/react/src/components/Modal/index.test.tsx
@@ -144,3 +144,18 @@ test('on close, focus returns to the element that opened the modal', (t) => {
 
 	t.is(document.activeElement, trigger);
 });
+
+test('existing body styles are preserved when the modal closes', (t) => {
+	document.body.style.overflow = 'visible';
+	const bodyCSSText = document.body.style.cssText;
+
+	render(<Controlled isOpen />);
+
+	// body styles should be overwritten on open
+	t.not(document.body.style.cssText, bodyCSSText);
+
+	fireEvent.click(document.activeElement);
+
+	// and restored on close
+	t.is(document.body.style.cssText, bodyCSSText);
+});

--- a/website/docs/components/modal.mdx
+++ b/website/docs/components/modal.mdx
@@ -58,14 +58,16 @@ function ModalWithButton() {
 				title="Confirm the prompt"
 				isOpen={isOpen}
 				onRequestClose={close}
-				actions={[
-					<Button variant="outline" color="base" onClick={close}>
-						Also confirm
-					</Button>,
-					<Button variant="solid" onClick={close}>
-						Confirm
-					</Button>,
-				]}
+				actions={(
+					<>
+						<Button variant="outline" color="base" onClick={close}>
+							Also confirm
+						</Button>
+						<Button variant="solid" onClick={close}>
+							Confirm
+						</Button>
+					</>
+				)}
 			>
 				<p>
 					This is a demo modal.


### PR DESCRIPTION
This ended up being trickier than expected since scrollbar width can vary from browser to browser, not to mention the fact that site authors can change its width with [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) in some browsers ([it's not well supported yet](https://caniuse.com/mdn-css_properties_scrollbar-width)).

The solution compares the width of [window.innerWidth](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth) (the entire window's width including the scrollbar) against the width of [document.documentElement.clientWidth](https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement) (the window's width _without_ the scrollbar) to dynamically set a body padding that exactly matches the width of the scrollbar. This prevents the document from shifting on open and should work for all browsers and all future browsers.

Addresses [NDS-334].

[NDS-334]: https://wwnorton.atlassian.net/browse/NDS-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ