### PR TITLE
Fix double-modal focus management NDS-368

### DIFF
--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -382,7 +382,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 		const { isOpen } = this.state;
 		if (!isOpen) return;
 		if (e.key === 'Escape' && closeOnEscape) this.requestClose();
-		if (e.key === 'Tab') {
+		if (e.key === 'Tab' && (this.dialog?.contains(document.activeElement) || !document.activeElement)) {
 			const tabbable = (this.dialog) ? getFocusable(this.dialog) : [];
 			if (tabbable.length) {
 				let element: HTMLElement | undefined;

--- a/packages/react/src/components/Modal/index.stories.tsx
+++ b/packages/react/src/components/Modal/index.stories.tsx
@@ -100,8 +100,9 @@ export const ComplexModal = (args: ModalProps) => {
 				hideTitle
 				isOpen={resultOpen}
 				onRequestClose={closeResult}
+				actions={(<Button variant="solid" onClick={closeResult}>I&apos;m sure</Button>)}
 			>
-				{ `Hello, ${firstName} ${lastName}!` }
+				{ `Are you sure, ${firstName} ${lastName}?` }
 			</Modal>
 		</>
 	);


### PR DESCRIPTION
When a modal dialog is opened on top of another modal dialog, both are listening for <kbd>Tab</kbd> keypresses to manage focus, which makes it impossible to move focus on the topmost modal dialog. This fixes that by only listening for <kbd>Tab</kbd> keypresses when [`activeElement`](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement) is inside the dialog.