### PR TITLE
Dropdown updates

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -292,6 +292,7 @@ export const Dropdown = ({
 			>
 				<Listbox
 					id={listboxId}
+					aria-labelledby={labelId}
 					multiselectable={false}
 					className={listboxClass}
 					optionClass="nds-dropdown__option"

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -41,6 +41,7 @@ export const Dropdown = ({
 	descriptionId: descIdProp,
 	buttonId: buttonIdProp,
 	listboxId: listboxIdProp,
+	selectedMarker = 'check',
 	disabled,
 	children,
 	placement = 'bottom-start',
@@ -296,6 +297,7 @@ export const Dropdown = ({
 					multiselectable={false}
 					className={listboxClass}
 					optionClass="nds-dropdown__option"
+					optionProps={{ marker: selectedMarker }}
 					selected={selected}
 					onChange={changeHandler}
 					focusableIndex={optionFocusIndex}

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -65,7 +65,13 @@ export const Dropdown = ({
 		typeof transitionProp | undefined
 	>(transitionProp);
 	const [optionFocusIndex, setOptionFocusIndex] = React.useState(0);
-	const { selected, toggle } = useSelect(false, [selectedProp]);
+	const { selected, select } = useSelect(false, [selectedProp]);
+
+	React.useEffect(() => {
+		if (selectedProp !== selected[0]) select(selectedProp);
+	// only update if the selected option is being controlled
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [selectedProp]);
 
 	const listboxId = listboxIdProp || `${id}-listbox`;
 	const currentId = `${id}-curr`;
@@ -164,7 +170,7 @@ export const Dropdown = ({
 			const { value } = props;
 			onChange({ value, contents: props.label });
 		} else {
-			toggle(props.value);
+			select(props.value);
 		}
 
 		setButtonContents(props.label);

--- a/packages/react/src/components/Dropdown/types.ts
+++ b/packages/react/src/components/Dropdown/types.ts
@@ -103,4 +103,6 @@ export interface DropdownProps extends FieldInfoCoreProps, PopperInherited, Base
 	}) => void;
 	/** If set, the focusable dropdown option should be focused when it is rendered. */
 	autofocus?: boolean;
+	/** Set the visual indicator for the selected option. */
+	selectedMarker?: 'check' | 'dot';
 }

--- a/packages/react/src/components/Listbox/Option.tsx
+++ b/packages/react/src/components/Listbox/Option.tsx
@@ -20,18 +20,22 @@ export const Option = React.forwardRef<HTMLLIElement, OptionProps>(({
 	children,
 	...props
 }: OptionProps, ref) => {
-	const defaultMarker = React.useMemo(() => (
-		<span className="nds-option__marker" aria-hidden={!selected}>
-			<Icon
-				variant="check"
-				color={(selected) ? 'currentColor' : 'transparent'}
-				// not all screen readers announce aria-selected, so use
-				// the marker to convey the state textually
-				aria-label={(selected) ? 'Checked' : undefined}
-				size="0.875em"
-			/>
-		</span>
-	), [selected]);
+	const selectedMarker = React.useMemo(() => {
+		if (React.isValidElement(marker)) return marker;
+		return (
+			<span className="nds-option__marker" aria-hidden={!selected}>
+				<Icon
+					variant={(marker !== 'dot') ? 'check' : undefined}
+					icon={(marker === 'dot') ? { children: <circle r="6" cx="12" cy="12" /> } : undefined}
+					color={(selected) ? 'currentColor' : 'transparent'}
+					// not all screen readers announce aria-selected, so use
+					// the marker to convey the state textually
+					aria-label={(selected) ? 'Checked' : undefined}
+					size="0.875em"
+				/>
+			</span>
+		);
+	}, [marker, selected]);
 
 	return (
 		<li
@@ -44,7 +48,7 @@ export const Option = React.forwardRef<HTMLLIElement, OptionProps>(({
 			aria-disabled={(disabled) ? 'true' : undefined}
 			role="option"
 		>
-			{ (marker === undefined) ? defaultMarker : marker }
+			{ selectedMarker }
 			{ label || children }
 		</li>
 	);

--- a/packages/react/src/components/Listbox/types.ts
+++ b/packages/react/src/components/Listbox/types.ts
@@ -17,10 +17,9 @@ export interface OptionProps extends OptionBase {
 	value: string | number;
 	/**
 	 * An element that comes before the label/children, similar to CSS `::marker`.
-	 * Default is `<Icon variant="check" />`. Disable it entirely with `null`.
+	 * Defaults to a check mark, but can be set as a dot or a React element.
 	 */
-	marker?: React.ReactNode | null;
-
+	marker?: React.ReactElement | 'check' | 'dot';
 	optionClass?: string;
 }
 


### PR DESCRIPTION
This fixes two dropdown bugs and adds a new "dot" selected visual indicator for [NERD-2209].

- The first fix uses the dropdown's label as an accessible name on the dropdown's listbox, which addresses [NDS-367] (93cfc7018c793cf662a5d964e47a27e240824320).
- The second fix was something I found while updating this and isn't currently ticketed. Our "fully controlled" story wasn't reflecting the selected option in the listbox (there wasn't a check next to the selected item). This was because it was only using the `selected` prop as an initial value. [NDS-369]

[NERD-2209]: https://wwnorton.atlassian.net/browse/NERD-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NDS-367]: https://wwnorton.atlassian.net/browse/NDS-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NDS-369]: https://wwnorton.atlassian.net/browse/NDS-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ