### PR TITLE
Improve callout naming conditions

### DIFF
--- a/packages/react/src/components/Callout/Callout.tsx
+++ b/packages/react/src/components/Callout/Callout.tsx
@@ -58,7 +58,7 @@ export const Callout: React.FunctionComponent<CalloutProps> = ({
 	if (isDismissed) return null;
 
 	return (
-		<Tag className={classes} data-border={border} aria-labelledby={titleId} {...props}>
+		<Tag className={classes} data-border={border} aria-labelledby={(title && tag !== 'div') ? titleId : undefined} {...props}>
 			{ title && (
 				<header className={headerClass}>
 					{ icon && <span className={iconClass}><Icon {...iconProps} /></span> }

--- a/packages/react/src/components/Callout/index.test.tsx
+++ b/packages/react/src/components/Callout/index.test.tsx
@@ -1,0 +1,28 @@
+import test from 'ava';
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Callout } from '.';
+
+test.afterEach(cleanup);
+
+// The default <aside> is an ARIA landmark and should be labelled by the title
+test('a Callout uses its title for its accessible name', async (t) => {
+	const name = 'Foo';
+	render(<Callout title={name} />);
+
+	t.truthy(screen.queryByRole('complementary', { name }));
+});
+
+// <div> callouts are _not_ ARIA landmarks, and should therefore not have an accessible name
+test('a div Callout does not use its title as an accessible name', async (t) => {
+	const name = 'Foo';
+	render(<Callout title={name} tag="div" />);
+
+	t.falsy(screen.queryByRole('complementary', { name }));
+});
+
+test('a Callout without a title is not rendered as a landmark', async (t) => {
+	render(<Callout />);
+
+	t.falsy(screen.queryByRole('complementary'));
+});

--- a/packages/react/src/components/Callout/index.test.tsx
+++ b/packages/react/src/components/Callout/index.test.tsx
@@ -1,6 +1,7 @@
 import test from 'ava';
 import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Callout } from '.';
 
 test.afterEach(cleanup);
@@ -24,5 +25,15 @@ test('a div Callout does not use its title as an accessible name', async (t) => 
 test('a Callout without a title is not rendered as a landmark', async (t) => {
 	render(<Callout />);
 
+	t.falsy(screen.queryByRole('complementary'));
+});
+
+test('clicking the dismiss button dismisses the callout', async (t) => {
+	const name = 'Foo';
+	render(<Callout title={name} dismissible />);
+
+	t.truthy(screen.queryByRole('complementary'));
+
+	await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 	t.falsy(screen.queryByRole('complementary'));
 });


### PR DESCRIPTION
This fixes a condition where Callout can be rendered with an invalid `aria-labelledby` attribute. While this doesn't present any real-world accessibility issues since assistive tech will just ignore it, it's technically invalid and accessibility tools do flag it.

I also went ahead and added tests to better capture the naming conventions of Callout.

## Context

Callout can either be rendered as an `<aside>` (default) or a `<div>`. When it's rendered as an `<aside>` and it has a title, it should use that title to name the Callout because landmark roles are more effective when they have an accessible name ([the aside element is mapped to the complementary role](https://www.w3.org/TR/html-aria/#el-aside)). But when it's rendered as a `<div>`, that same naming convention shouldn't exist. This fixes that.