### PR TITLE
Dropdown issues

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -316,7 +316,7 @@ export const Dropdown = ({
 					selected={selected}
 					onChange={changeHandler}
 					focusableIndex={optionFocusIndex}
-					autofocus={autofocus}
+					autofocus={isOpen && autofocus}
 					ref={setListbox}
 				>
 					{options}

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -68,7 +68,10 @@ export const Dropdown = ({
 	const { selected, select } = useSelect(false, [selectedProp]);
 
 	React.useEffect(() => {
-		if (selectedProp !== selected[0]) select(selectedProp);
+		if (selectedProp !== selected[0]) {
+			select(selectedProp);
+			setButtonContents(contentsProp);
+		}
 	// only update if the selected option is being controlled
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [selectedProp]);

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { FieldInfo } from '../Field';
 import { canUseDOM } from '../../utilities/environment';
@@ -50,62 +50,6 @@ export const Dropdown = ({
 	distance = 4,
 	modifiers,
 }: DropdownProps) => {
-	const [isOpen, setOpen] = React.useState(isOpenProp);
-	const uniqueId = useId();
-	const id = idProp || uniqueId;
-	const labelId = labelIdProp || `${id}-label`;
-	const descId = descIdProp || `${id}-desc`;
-	const buttonId = buttonIdProp || `${id}-btn`;
-	const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
-	const [listbox, setListbox] = React.useState<HTMLUListElement | null>(null);
-	const [listboxWidth, setListBoxWidth] = React.useState<number>();
-	const [buttonContents, setButtonContents] = React.useState<React.ReactNode>(contentsProp);
-	const [shouldReturnFocus, setShouldReturnFocus] = React.useState(false);
-	const [transition, setTransition] = React.useState<
-		typeof transitionProp | undefined
-	>(transitionProp);
-	const [optionFocusIndex, setOptionFocusIndex] = React.useState(0);
-	const { selected, select } = useSelect(false, [selectedProp]);
-
-	React.useEffect(() => {
-		if (selectedProp !== selected[0]) {
-			select(selectedProp);
-			setButtonContents(contentsProp);
-		}
-	// only update if the selected option is being controlled
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [selectedProp]);
-
-	const listboxId = listboxIdProp || `${id}-listbox`;
-	const currentId = `${id}-curr`;
-	const getListboxWidth = React.useRef(false);
-
-	/** Attempt to open the listbox. */
-	const openListbox = React.useCallback(() => {
-		if (onRequestOpen) onRequestOpen();
-		else setOpen(true);
-	}, [onRequestOpen]);
-
-	/** Attempt to close the listbox. */
-	const closeListbox = React.useCallback((): void => {
-		if (onRequestClose) onRequestClose();
-		else setOpen(false);
-	}, [onRequestClose]);
-
-	/** Toggle the listbox on button click. */
-	const buttonClickHandler = (): void => {
-		if (isOpen) closeListbox();
-		else openListbox();
-	};
-
-	/** Open the listbox on arrow up or down. */
-	const buttonKeydownHandler = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
-		if (['ArrowDown', 'ArrowUp'].includes(e.key)) {
-			e.preventDefault();
-			openListbox();
-		}
-	};
-
 	/** A compare function that will sort children by value */
 	const sorter = React.useMemo(() => {
 		if (!sort) return null;
@@ -137,6 +81,68 @@ export const Dropdown = ({
 		});
 		return sorter ? opts.sort(sorter) : opts;
 	}, [children, sorter]);
+
+	const findFocusedIndex = useCallback((value: string | number | undefined) => {
+		const idx = options.findIndex((o) => o.value === value);
+		return idx === -1 ? 0 : idx;
+	}, [options]);
+
+	const [isOpen, setOpen] = React.useState(isOpenProp);
+	const uniqueId = useId();
+	const id = idProp || uniqueId;
+	const labelId = labelIdProp || `${id}-label`;
+	const descId = descIdProp || `${id}-desc`;
+	const buttonId = buttonIdProp || `${id}-btn`;
+	const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
+	const [listbox, setListbox] = React.useState<HTMLUListElement | null>(null);
+	const [listboxWidth, setListBoxWidth] = React.useState<number>();
+	const [buttonContents, setButtonContents] = React.useState<React.ReactNode>(contentsProp);
+	const [shouldReturnFocus, setShouldReturnFocus] = React.useState(false);
+	const [transition, setTransition] = React.useState<
+		typeof transitionProp | undefined
+	>(transitionProp);
+	const [optionFocusIndex, setOptionFocusIndex] = React.useState(findFocusedIndex(selectedProp));
+	const { selected, select } = useSelect(false, [selectedProp]);
+
+	const listboxId = listboxIdProp || `${id}-listbox`;
+	const currentId = `${id}-curr`;
+	const getListboxWidth = React.useRef(false);
+
+	/** Attempt to open the listbox. */
+	const openListbox = React.useCallback(() => {
+		if (onRequestOpen) onRequestOpen();
+		else setOpen(true);
+	}, [onRequestOpen]);
+
+	/** Attempt to close the listbox. */
+	const closeListbox = React.useCallback((): void => {
+		if (onRequestClose) onRequestClose();
+		else setOpen(false);
+	}, [onRequestClose]);
+
+	/** Toggle the listbox on button click. */
+	const buttonClickHandler = (): void => {
+		if (isOpen) closeListbox();
+		else openListbox();
+	};
+
+	/** Open the listbox on arrow up or down. */
+	const buttonKeydownHandler = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+		if (['ArrowDown', 'ArrowUp'].includes(e.key)) {
+			e.preventDefault();
+			openListbox();
+		}
+	};
+
+	React.useEffect(() => {
+		if (selectedProp !== selected[0]) {
+			select(selectedProp);
+			setButtonContents(contentsProp);
+			setOptionFocusIndex(findFocusedIndex(selectedProp));
+		}
+	// only update if the selected option is being controlled
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [selectedProp]);
 
 	/** Attempt to close the listbox on document click. */
 	const documentClickHandler = React.useCallback(

--- a/packages/react/src/components/Dropdown/index.test.tsx
+++ b/packages/react/src/components/Dropdown/index.test.tsx
@@ -218,3 +218,30 @@ test('a dropdown is closed when it is disabled', (t) => {
 	rerender(<Dropdown {...defaultProps} isOpen disabled />);
 	t.falsy(screen.queryByRole('listbox'));
 });
+
+test('a dropdown button content is updated', (t) => {
+	const children = [
+		<Dropdown.Option key={0} value={1}>1</Dropdown.Option>,
+		<Dropdown.Option key={1} value={2}>2</Dropdown.Option>,
+		<Dropdown.Option key={2} value={3}>3</Dropdown.Option>,
+		<Dropdown.Option key={3} value={4}>4</Dropdown.Option>,
+		<Dropdown.Option key={4} value={5}>5</Dropdown.Option>,
+	];
+	const { rerender } = render(
+		<Dropdown {...defaultProps} selected={1} buttonContents={1}>
+			{children}
+		</Dropdown>,
+	);
+
+	rerender(
+		<Dropdown {...defaultProps} selected={2} buttonContents={2}>
+			{children}
+		</Dropdown>,
+	);
+
+	t.truthy(
+		// There's some kind of whitespace before and after the number
+		// in the label, curious.
+		screen.queryByRole('button', { name: /\w*2\w*/ }),
+	);
+});

--- a/packages/react/src/components/Dropdown/index.test.tsx
+++ b/packages/react/src/components/Dropdown/index.test.tsx
@@ -224,8 +224,6 @@ test('a dropdown button content is updated', (t) => {
 		<Dropdown.Option key={0} value={1}>1</Dropdown.Option>,
 		<Dropdown.Option key={1} value={2}>2</Dropdown.Option>,
 		<Dropdown.Option key={2} value={3}>3</Dropdown.Option>,
-		<Dropdown.Option key={3} value={4}>4</Dropdown.Option>,
-		<Dropdown.Option key={4} value={5}>5</Dropdown.Option>,
 	];
 	const { rerender } = render(
 		<Dropdown {...defaultProps} selected={1} buttonContents={1}>
@@ -244,4 +242,44 @@ test('a dropdown button content is updated', (t) => {
 		// in the label, curious.
 		screen.queryByRole('button', { name: /\w*2\w*/ }),
 	);
+});
+
+test('a dropdown should focus on selected option if picked via props on mount', (t) => {
+	const children = [
+		<Dropdown.Option key={0} value={1}>1</Dropdown.Option>,
+		<Dropdown.Option key={1} value={2}>2</Dropdown.Option>,
+		<Dropdown.Option key={2} value={3}>3</Dropdown.Option>,
+	];
+	render(
+		<Dropdown {...defaultProps} selected={2} isOpen>
+			{children}
+		</Dropdown>,
+	);
+
+	const { textContent } = document.activeElement as Element;
+
+	t.true(textContent === '2');
+});
+
+test('a dropdown should focus on selected option if picked via props on update', (t) => {
+	const children = [
+		<Dropdown.Option key={0} value={1}>1</Dropdown.Option>,
+		<Dropdown.Option key={1} value={2}>2</Dropdown.Option>,
+		<Dropdown.Option key={2} value={3}>3</Dropdown.Option>,
+	];
+	const { rerender } = render(
+		<Dropdown {...defaultProps} selected={1}>
+			{children}
+		</Dropdown>,
+	);
+
+	rerender(
+		<Dropdown {...defaultProps} selected={2} isOpen>
+			{children}
+		</Dropdown>,
+	);
+
+	const { textContent } = document.activeElement as Element;
+
+	t.true(textContent === '2');
 });


### PR DESCRIPTION
Solves 3 issues with the Dropdown component.

# Issue 1: Content Button doesn't update when fully controlled
In Dropdown, When we set Button Contents dynamically i.e. from local state/Redux state then, Updated Button contents text not setting on Dropdown. However, value is setting in Selected prop and also when we open Options, it’s been set correctly.

[NDS-378]

# Issue 2: When fully controlled, focus doesn't change to selected option
If there is a NDS dropdown where the selected prop in the dropdown component is set to the value of one of the dropdown options, when the user expands the dropdown for the first time, the option whose value is set as selected in the dropdown props has a check mark before it but there is no blue highlight on it.

The blue highlight (focus) is by default set to the first option in the dropdown instead of the selected option.

[NDS-377]

# Issue 3: When multiple dropdowns, they compete for focus change
If we have two or more dropdowns on the same page. If we open the first dropdown and (without clicking anywhere) then click on another dropdown, the second opened dropdown does not have focus (blue highlight) on any option.

[NDS-379]


[NDS-378]: https://wwnorton.atlassian.net/browse/NDS-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NDS-377]: https://wwnorton.atlassian.net/browse/NDS-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NDS-379]: https://wwnorton.atlassian.net/browse/NDS-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ