### PR TITLE
Use default link display value [NDS-416]

### DIFF
--- a/packages/core/src/components/link/index.scss
+++ b/packages/core/src/components/link/index.scss
@@ -35,7 +35,6 @@
 }
 
 @mixin base {
-	display: inline-flex;
 	color: var(--nds-link-color);
 	text-decoration: var(--nds-link-decoration);
 }

--- a/packages/core/src/components/link/index.scss
+++ b/packages/core/src/components/link/index.scss
@@ -40,6 +40,7 @@
 }
 
 @mixin launch {
+	display: inline-flex;
 	margin-left: 1px;
 	font-size: 0.875em;
 }


### PR DESCRIPTION
While writing a recent blog post, I noticed some odd wrapping behavior with long links in limited viewports:

![image](https://github.com/wwnorton/design-system/assets/7939037/1656335c-1b2d-44cb-8040-7fb07cfbe8b1)

After investigating, I realized this was because of the `display: inline-flex;` that we're setting on links in the design system. Here's that same link after this fix:

![image](https://github.com/wwnorton/design-system/assets/7939037/df5cec0d-743e-4975-a7d5-f84b0aa713e7)

Much better!
