### PR TITLE
Fix Disclosure Component Not Providing Proper Feedback for Screen Reader Users

### DIFF
--- a/packages/react/src/components/Disclosure/Disclosure.tsx
+++ b/packages/react/src/components/Disclosure/Disclosure.tsx
@@ -192,6 +192,7 @@ export const Disclosure = React.forwardRef<HTMLDetailsElement, DisclosureProps>(
 				marker={Marker}
 				onClick={summaryClickHandler}
 				markerPosition={markerPos}
+				aria-expanded={isOpen}
 			>
 				<span className={`${baseName}__title`}>{ summary }</span>
 			</BaseSummary>

--- a/packages/react/src/components/Disclosure/index.stories.tsx
+++ b/packages/react/src/components/Disclosure/index.stories.tsx
@@ -51,16 +51,16 @@ export const Controlled: Story<DisclosureProps> = (args) => {
 	// load a random poem
 	const getContents = async (): Promise<void> => {
 		setSummary(`${summaryText.current} (retrieving...)`);
-		const [{ content, poet, title }] = await fetch('https://www.poemist.com/api/v1/randompoems')
+		const [{ title, author, lines }] = await fetch('https://poetrydb.org/random/1/title,author,lines')
 			.then((r) => r.json());
 		setContents((
 			<>
 				<h2>{ title }</h2>
-				<pre>{ content }</pre>
+				<pre>{ lines.join('\n') }</pre>
 				<div>
 					&mdash;
 					{' '}
-					{ poet.name }
+					{ author }
 				</div>
 			</>
 		));


### PR DESCRIPTION

This pull request addresses an issue where screen readers (NVDA and JAWS) in Chromium-based browsers (Chrome, Edge, Opera) do not properly update their internal states (buffers) with changes made to the DOM. This results in inaccurate reporting of the "collapsed" state of the <disclosure> component.

• Screen readers in Chromium-based browsers do not accurately reflect DOM changes, leading to incorrect element state reports.
• This issue was verified with NVDA and JAWS on Windows.
• The fix was tested with NVDA and JAWS on Windows.
• Mobile devices were not tested.

Note: this issue was not observed in Firefox browser.