### PR TITLE
Only call onColorSchemeChange when the color scheme changes

### DIFF
--- a/packages/react/src/providers/ThemeProvider/index.tsx
+++ b/packages/react/src/providers/ThemeProvider/index.tsx
@@ -60,6 +60,7 @@ export const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = ({
 			parentColorScheme,
 		),
 	);
+	const prevScheme = React.useRef(colorScheme);
 
 	// root <ThemeProvider>: update colorScheme when the user changes their OS scheme
 	React.useEffect(() => {
@@ -89,7 +90,10 @@ export const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = ({
 	}, [parentColorScheme, schemeProp]);
 
 	React.useEffect(() => {
-		if (onColorSchemeChange) onColorSchemeChange(colorScheme);
+		if (prevScheme.current !== colorScheme) {
+			prevScheme.current = colorScheme;
+			if (onColorSchemeChange) onColorSchemeChange(colorScheme);
+		}
 	}, [colorScheme, onColorSchemeChange]);
 
 	const theme = React.useMemo(


### PR DESCRIPTION
`onColorSchemeChange` was triggering on first load, regardless of whether the stored `colorScheme` value was different. This fixes that.

Closes NDS-448.