### PR TITLE
fix: solve tabs appearing on top of fixed elements when focused

### DIFF
--- a/packages/core/src/components/tab/index.scss
+++ b/packages/core/src/components/tab/index.scss
@@ -23,7 +23,7 @@
 	--nds-selected-border: #{tokens.$selected-border};
 	--nds-border-y: #{tokens.$border-y};
 	--nds-base-border: #{tokens.$border-base};
-	--nds-zindex-focus: 9999;
+	--nds-zindex-focus: var(--nds-zindex-dropdown);
 
 	position: relative;
 	box-sizing: border-box;


### PR DESCRIPTION
When the user focused on a tab the tab appeared on top of fixed elements.

This was caused by a hardcoded value for zindex of 9999, I changed it to the same zindex that applies to dropdown elements