### PR TITLE
fix: solve visual bug where table labels appear overlapping content

### DIFF
--- a/packages/core/src/components/table/index.scss
+++ b/packages/core/src/components/table/index.scss
@@ -217,6 +217,18 @@
 			}
 		}
 
+		.nds-table-header {
+			position: relative;
+			height: 0;
+			opacity: 0;
+
+			@include device.media-up('sm') {
+				position: static;
+				height: auto;
+				opacity: 1;
+			}
+		}
+
 		.nds-table-sort-button {
 			display: none;
 			padding: 0;

--- a/packages/react/src/components/Table/TableHeader/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader/TableHeader.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { TableHeaderProps } from '../types';
 
+const css = {
+	base: 'nds-table-header',
+};
+
 export const TableHeader = ({ children, ...others }: TableHeaderProps) => {
 	return (
-		<thead {...others}>
+		<thead className={css.base} {...others}>
 			<tr>{children}</tr>
 		</thead>
 	);


### PR DESCRIPTION
When in XS breakpoint, for non-sortable tables, the labels of the columns appear overlapping the content. I solved it by hiding them visually, they should still be accessible via Screen Reader.