### PR TITLE
fix: ensure that tooltips & popovers hide when not hovered

### DIFF
--- a/packages/react/src/components/Tooltip/index.test.tsx
+++ b/packages/react/src/components/Tooltip/index.test.tsx
@@ -154,3 +154,15 @@ test("complex tooltip contents are flattened and used as the reference's label e
 	);
 	t.truthy(screen.queryByRole('button', { name: FLATTENED }));
 });
+
+test("tooltips close when the user moves their pointer outside the reference even when pointerleave doesn't trigger", async (t) => {
+	const user = userEvent.setup();
+
+	const hideDelay = 200;
+	render(<TooltipFixture isOpen trigger="pointerenter" hideDelay={hideDelay} />);
+
+	t.truthy(screen.getByRole('tooltip', { hidden: true }));
+
+	await user.pointer({ target: document.body });
+	t.falsy(screen.queryByRole('tooltip', { hidden: true }));
+});

--- a/packages/react/src/utilities/popperTriggers/types.ts
+++ b/packages/react/src/utilities/popperTriggers/types.ts
@@ -8,7 +8,8 @@ export type PopperTriggersClose =
 	| 'click.external'
 	| 'escape'
 	| 'blur'
-	| 'pointerleave';
+	| 'pointerleave'
+	| 'pointermove.document';
 
 export interface UsePopperTriggersProps extends PopperCoreProps {
 	/** Indicates whether the popper is open or closed. */


### PR DESCRIPTION
There are some scenarios where tooltips that were opened on hover don't close after the user has moved their pointer away. While I still only have theories about why this happens, I had some time to look into this recently and realized that we could just listen for `pointermove` events on the document and close the tooltip if it shouldn't be open.

Addresses [NDS-447].

[NDS-447]: https://wwnorton.atlassian.net/browse/NDS-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ