### PR TITLE
Eliminate React Deprecations

### DIFF
--- a/packages/react/src/components/BaseButton/BaseButton.tsx
+++ b/packages/react/src/components/BaseButton/BaseButton.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { BaseButtonProps } from './types';
 
-export const defaultProps: BaseButtonProps = {
-	active: false,
-	activeClass: 'active',
-	type: 'button',
-};
-
 /**
  * A base `<button>` component with `type="button"` by default (browser default
  * is "submit") and a polyfill to ensure that :active is triggered while the
@@ -16,14 +10,14 @@ export const defaultProps: BaseButtonProps = {
 export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
 	(
 		{
-			active = defaultProps.active,
-			activeClass = defaultProps.activeClass,
+			active = false,
+			activeClass = 'active',
 			onKeyDown,
 			onKeyUp,
 			onBlur,
 			className,
 			children,
-			type = defaultProps.type,
+			type = 'button',
 			...props
 		}: BaseButtonProps,
 		ref,
@@ -64,5 +58,3 @@ export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
 		);
 	},
 );
-
-BaseButton.defaultProps = defaultProps;

--- a/packages/react/src/components/BaseInput/BaseInput.tsx
+++ b/packages/react/src/components/BaseInput/BaseInput.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { useForwardedRef, useLayoutEffect, useValidation } from '../../utilities';
 import { BaseInputProps } from './types';
 
-const defaultProps: BaseInputProps = {
-	validateOnDOMChange: true,
-};
-
 /**
  * A base `<input>` component. Adds a callback for the DOM's `change` event
  * (`onDOMChange`), which does not exist in React.
@@ -15,7 +11,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 		{
 			errors: errorsProp,
 			validateOnChange,
-			validateOnDOMChange = defaultProps.validateOnDOMChange,
+			validateOnDOMChange = true,
 			validators,
 			// pull out maxLength because it prevents user input past the given
 			// length, which is an anti-pattern according to our usage guidelines.
@@ -116,5 +112,3 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 		);
 	},
 );
-
-BaseInput.defaultProps = defaultProps;

--- a/packages/react/src/components/BaseTextArea/BaseTextArea.tsx
+++ b/packages/react/src/components/BaseTextArea/BaseTextArea.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { useForwardedRef, useLayoutEffect, useValidation } from '../../utilities';
 import { BaseTextAreaProps } from './types';
 
-const defaultProps: BaseTextAreaProps = {
-	validateOnDOMChange: true,
-};
-
 /**
  * A base `<textarea>` component. Adds a callback for the DOM's `change` event
  * (`onDOMChange`), which does not exist in React.
@@ -17,7 +13,7 @@ export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaPr
 			autoSize = false,
 			errors: errorsProp,
 			validateOnChange,
-			validateOnDOMChange = defaultProps.validateOnDOMChange,
+			validateOnDOMChange = true,
 			validators,
 			// pull out maxLength because it prevents user textarea past the given
 			// length, which is an anti-pattern according to our usage guidelines.
@@ -124,5 +120,3 @@ export const BaseTextArea = React.forwardRef<HTMLTextAreaElement, BaseTextAreaPr
 		);
 	},
 );
-
-BaseTextArea.defaultProps = defaultProps;

--- a/packages/react/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/react/src/components/LiveRegion/LiveRegion.tsx
@@ -15,12 +15,6 @@ const srOnly: React.CSSProperties = {
 	border: '0',
 };
 
-const defaultProps: LiveRegionProps = {
-	removeAfter: 450,
-	updateAfter: 50,
-	'aria-live': 'assertive',
-};
-
 /**
  * Render an ARIA live region as a React Portal. Changing the `children` of this
  * component will result in
@@ -34,11 +28,11 @@ const defaultProps: LiveRegionProps = {
  * - [MDN - ARIA Live Regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
  */
 export const LiveRegion: React.FunctionComponent<LiveRegionProps> = ({
-	removeAfter = defaultProps.removeAfter,
-	updateAfter = defaultProps.updateAfter,
+	removeAfter = 450,
+	updateAfter = 50,
 	visible,
 	'aria-atomic': ariaAtomic,
-	'aria-live': ariaLive = defaultProps['aria-live'],
+	'aria-live': ariaLive = 'assertive',
 	'aria-relevant': ariaRelevant,
 	children,
 	className,
@@ -100,8 +94,6 @@ export const LiveRegion: React.FunctionComponent<LiveRegionProps> = ({
 	if (typeof document === 'undefined') return null;
 	return createPortal(shouldRender ? Node : null, document.body);
 };
-
-LiveRegion.defaultProps = defaultProps;
 
 /**
  * Monitor an element for content changes. Returns the element's changed content,

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -6,20 +6,11 @@ import { BaseTextArea } from '../BaseTextArea';
 import { TextFieldProps } from './types';
 import { useId } from '../../utilities';
 
-const defaultProps: Partial<TextFieldProps> = {
-	counterStart: 25,
-	counter: ({ remaining, max }) => {
-		if (remaining < 0) return null;
-		return `${remaining}/${max} characters remaining`;
-	},
-	type: 'text',
-};
-
 export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement, TextFieldProps>(
 	(
 		{
 			// options
-			counterStart = defaultProps.counterStart,
+			counterStart = 25,
 			validators,
 			validateOnChange,
 			validateOnDOMChange,
@@ -35,7 +26,10 @@ export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement
 			addonAfter,
 			feedback,
 			errors: errorsProp,
-			counter = defaultProps.counter,
+			counter = ({ remaining, max }) => {
+				if (remaining < 0) return null;
+				return `${remaining}/${max} characters remaining`;
+			},
 
 			// classes
 			baseName = 'nds-field',
@@ -65,7 +59,7 @@ export const TextField = React.forwardRef<HTMLInputElement & HTMLTextAreaElement
 			// <input> attributes
 			maxLength,
 			required,
-			type = defaultProps.type,
+			type = 'text',
 			value,
 
 			// event callbacks

--- a/packages/react/src/utilities/select/select.test.tsx
+++ b/packages/react/src/utilities/select/select.test.tsx
@@ -8,11 +8,11 @@ import { ErrorBoundary } from '../../../test/helpers/ErrorBoundary';
 test.afterEach(cleanup);
 
 const Fixture = ({
-	multiple,
-	handlerOnInput,
+	multiple = false,
+	handlerOnInput = false,
 	initialValue,
 	callSetSelected,
-	useDefaults,
+	useDefaults = false,
 }: {
 	multiple?: boolean;
 	handlerOnInput?: boolean;
@@ -43,13 +43,6 @@ const Fixture = ({
 			))}
 		</fieldset>
 	);
-};
-Fixture.defaultProps = {
-	multiple: false,
-	handlerOnInput: false,
-	initialValue: undefined,
-	callSetSelected: undefined,
-	useDefaults: false,
 };
 
 test('the default hook has nothing selected', async (t) => {


### PR DESCRIPTION
Consumers are seeing a handful of deprecation warnings because of code in the design system. This eliminates those deprecation warnings, which came from two sources:

1. Use of `defaultProps`, which was deprecated in function components a long time ago. (b09b7bdb1a61db40cf7a7b1f27783bfde74dacdf)
2. [React Transition Group](https://github.com/reactjs/react-transition-group)'s use of `ReactDOM.findDOMNode`, which was deprecated in React 19. (3a76cf19f5a348dea3cd008f34ce30fe43c047e7)