### PR TITLE
Allow modal dialogs to be aria-describedby

### DIFF
--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -295,6 +295,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 			children,
 			contentClass = `${this.baseName}__${Modal.bemElements.content}`,
 			backdropClass = `${this.baseName}__${Modal.bemElements.backdrop}`,
+			'aria-describedby': ariaDescribedby,
 		} = this.props;
 		const { isOpen, long } = this.state;
 		if (!isOpen) return null;
@@ -319,6 +320,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 					}}
 					onPointerDown={this.onPointerDownClick}
 					{...label}
+					aria-describedby={ariaDescribedby}
 				>
 					{this.Header}
 					<section

--- a/packages/react/src/components/Modal/index.stories.tsx
+++ b/packages/react/src/components/Modal/index.stories.tsx
@@ -69,11 +69,9 @@ export const DescribedByContents = (args: ModalProps) => {
 				aria-describedby={descriptionId}
 				{...args}
 			>
-				<section id={descriptionId}>
-					<p>
-						This modal dialog is described by its contents with <code>aria-describedby</code>.
-					</p>
-				</section>
+				<p id={descriptionId}>
+					This modal dialog is described by its contents with <code>aria-describedby</code>.
+				</p>
 			</Modal>
 		</>
 	);

--- a/packages/react/src/components/Modal/index.stories.tsx
+++ b/packages/react/src/components/Modal/index.stories.tsx
@@ -49,6 +49,39 @@ WithActionBar.args = {
 	children: shortContent,
 };
 
+export const DescribedByContents = (args: ModalProps) => {
+	const [isOpen, setOpen] = React.useState(false);
+	const descriptionId = React.useId();
+
+	const close = (): void => {
+		setOpen(false);
+		action('onRequestClose')();
+	};
+	return (
+		<>
+			<Button variant="solid" onClick={() => setOpen(true)}>
+				Open
+			</Button>
+			<Modal
+				isOpen={isOpen}
+				onOpen={action('onOpen')}
+				onRequestClose={close}
+				aria-describedby={descriptionId}
+				{...args}
+			>
+				<section id={descriptionId}>
+					<p>
+						This modal dialog is described by its contents with <code>aria-describedby</code>.
+					</p>
+				</section>
+			</Modal>
+		</>
+	);
+};
+DescribedByContents.args = {
+	title: 'Described Modal',
+};
+
 export const ComplexModal = (args: ModalProps) => {
 	const [firstNameRef, setFirstNameRef] = React.useState<HTMLInputElement | null>(null);
 	const [lastNameRef, setLastNameRef] = React.useState<HTMLInputElement | null>(null);
@@ -56,6 +89,8 @@ export const ComplexModal = (args: ModalProps) => {
 	const [lastName, setFirst] = React.useState('');
 	const [firstName, setLast] = React.useState('');
 	const [resultOpen, setResultOpen] = React.useState(false);
+	const formId = React.useId();
+
 	const open = (): void => setOpen(true);
 	const close = (): void => {
 		setOpen(false);
@@ -89,9 +124,10 @@ export const ComplexModal = (args: ModalProps) => {
 				onOpen={action('onOpen')}
 				onRequestClose={close}
 				closeOnEscape={!resultOpen}
+				aria-describedby={formId}
 				{...args}
 			>
-				<form onSubmit={submit} onChange={handleChange}>
+				<form onSubmit={submit} onChange={handleChange} id={formId}>
 					<TextField required value={firstName} ref={setFirstNameRef}>
 						First Name
 					</TextField>


### PR DESCRIPTION
Our Modal dialog doesn't allow the user to set the [aria-describedby](https://w3c.github.io/aria/#aria-describedby) attribute, which makes it impossible to provide a description for the dialog. The [dialog role](https://w3c.github.io/aria/#dialog) explains why this is helpful:

> Authors SHOULD provide a dialog an accessible description, with the [aria-describedby](https://w3c.github.io/aria/#aria-describedby) attribute, for instances where authors have set initial keyboard focus on an element that follows content that outlines the purpose of the dialog. Assistive technology SHOULD give precedence to exposing author defined dialog accessible descriptions when a dialog is invoked and user focus is moved to a descendant of the dialog element.

addresses NERD-4186