### PR TITLE
Potential fix for code scanning alert no. 101: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Prepare ✅


### PR DESCRIPTION
Potential fix for [https://github.com/wwnorton/design-system/security/code-scanning/101](https://github.com/wwnorton/design-system/security/code-scanning/101)

To fix the issue, we need to explicitly define permissions for the `build` job. Since the `build` job only involves running commands and uploading artifacts, it does not require write permissions. The minimal permissions required are `contents: read`. This ensures the `GITHUB_TOKEN` is limited to read-only access to the repository contents.

The fix involves adding a `permissions` block to the `build` job in the `.github/workflows/pages.yml` file. No additional dependencies or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
