### PR TITLE
NDS-463: Accessibility Updates to Modal

### DIFF
--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -251,7 +251,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 			'nds-stuck': stickyHeader && stuckHeader,
 		});
 		return (
-			<header
+			<div
 				className={classes}
 				ref={(el): void => {
 					this.header = el;
@@ -259,7 +259,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 			>
 				{this.Title}
 				{this.CloseButton}
-			</header>
+			</div>
 		);
 	}
 
@@ -276,14 +276,14 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 			'nds-stuck': stickyActionBar && stuckFooter,
 		});
 		return (
-			<footer
+			<div
 				className={classes}
 				ref={(el): void => {
 					this.footer = el;
 				}}
 			>
 				{actions}
-			</footer>
+			</div>
 		);
 	}
 


### PR DESCRIPTION
Modified the Modal class, so it does not use <header> nor <footer> elements.
Instead, both were replaced with generic block elements, with the same attributes.
Having a <header> and a <footer> element inside a Modal is not considered a good practice, since these are basically to define page level sections.