### PR TITLE
fix: fix focus ring visible when user interacts with mouse

### DIFF
--- a/packages/core/src/components/checkbox/index.scss
+++ b/packages/core/src/components/checkbox/index.scss
@@ -15,8 +15,7 @@
 		border-color: transparent;
 	}
 
-	.focus + &,
-	:focus + & {
+	:focus-visible + & {
 		@include a11y.focus-halo;
 	}
 

--- a/packages/core/src/components/radio/index.scss
+++ b/packages/core/src/components/radio/index.scss
@@ -12,8 +12,7 @@
 		box-shadow: $-inner-ring;
 	}
 
-	.focus + &,
-	:focus + & {
+	:focus-visible + & {
 		@include a11y.focus-halo($-inner-ring);
 	}
 }

--- a/packages/core/src/components/tag/index.scss
+++ b/packages/core/src/components/tag/index.scss
@@ -46,7 +46,7 @@
 		box-shadow: none;
 	}
 
-	&:focus-within {
+	&:focus-visible {
 		@include a11y.focus-halo;
 	}
 
@@ -71,6 +71,10 @@
 
 	&:focus {
 		box-shadow: none;
+	}
+
+	&:focus-visible {
+		@include a11y.focus-halo;
 	}
 
 	&:hover,


### PR DESCRIPTION
In some component like a Radio Group, the focus ring appeared when the user interacted using a mouse, this is not the default behavior for those components, we changes the usage of focus pseudo selectors with focus-visible to make sure it keeps consistent with default browser behavior.

Closes NDS-494