### PR TITLE
fix(react): solves broken selection in radio group

### DIFF
--- a/packages/react/src/components/ChoiceField/ChoiceField.tsx
+++ b/packages/react/src/components/ChoiceField/ChoiceField.tsx
@@ -51,7 +51,6 @@ export const ChoiceField = React.forwardRef<HTMLFieldSetElement, ChoiceFieldProp
 		ref,
 	) => {
 		const [errors, setErrors] = React.useState(errorsProp);
-
 		const type = React.useMemo(() => {
 			if (multiple) return 'checkbox';
 			return 'radio';
@@ -72,6 +71,11 @@ export const ChoiceField = React.forwardRef<HTMLFieldSetElement, ChoiceFieldProp
 			return null;
 		}, [requiredIndicator, optionalIndicator, required]);
 
+		/**
+		 * The indexes of the checked choices. An empty object if no choice is checked.
+		 */
+		const [checkedIndexes, setCheckedIndexes] = React.useState<Record<number, boolean>>({});
+
 		const childMap = React.useCallback(
 			(children: React.ReactNode): React.ReactNode => {
 				// if it's a `<Choices>` element, use it with our `multiple`
@@ -80,24 +84,46 @@ export const ChoiceField = React.forwardRef<HTMLFieldSetElement, ChoiceFieldProp
 				}
 
 				// coerce into a list of `<Choice>` elements
-				return React.Children.map(children, (child) => {
+				return React.Children.map(children, (child, idx) => {
 					if (Array.isArray(child)) return childMap(child);
-					const baseProps: ChoiceProps = { name: name || id, type };
+					const baseProps: ChoiceProps = {
+						name: name || id,
+						type,
+						onChange: () =>
+							setCheckedIndexes((prev) => {
+								if (multiple) {
+									return {
+										...prev,
+										[idx]: !prev[idx],
+									};
+								}
+								return { [idx]: true };
+							}),
+					};
+
 					let value: string | number;
 					let props: ChoiceProps;
 					if (typeof child === 'string' || typeof child === 'number') {
 						value = child;
-						props = { ...baseProps, children: child };
+						props = { ...baseProps, children: child, checked: checkedIndexes[idx] };
 					} else if (React.isValidElement<ChoiceProps>(child)) {
 						value = (child.props.value || child.props.children || '').toString();
-						props = { ...child.props, ...baseProps };
+
+						let isChecked: boolean | undefined;
+						if (checkedIndexes !== null) {
+							isChecked = checkedIndexes[idx];
+						} else {
+							isChecked = child.props.defaultChecked || child.props.checked;
+						}
+
+						props = { ...child.props, ...baseProps, checked: isChecked };
 					} else {
 						throw new Error('invalid children');
 					}
 					return <Choice key={value} {...props} value={value} />;
 				});
 			},
-			[multiple, name, id, type],
+			[multiple, name, id, type, checkedIndexes],
 		);
 
 		const ChoiceElements = React.useMemo(() => childMap(childrenProp), [childrenProp, childMap]);

--- a/packages/react/src/components/ChoiceField/index.test.tsx
+++ b/packages/react/src/components/ChoiceField/index.test.tsx
@@ -1,6 +1,7 @@
 import test from 'ava';
 import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ChoiceField, Choice, Choices } from '.';
 
 // TODO: use something other than classes to select the control/thumbnail
@@ -97,6 +98,58 @@ test('when the label is not explicitly provided, the value is used for choice la
 	t.truthy(screen.getByLabelText('A'));
 	t.truthy(screen.getByLabelText('B'));
 	t.truthy(screen.getByLabelText('C'));
+});
+
+test('`ChoiceField` controls the checked state of radio choices', async (t) => {
+	const user = userEvent.setup();
+
+	render(<ChoiceField label={defaultLabel}>{defaultChoices}</ChoiceField>);
+
+	const [apple, banana, greenBean, tomato] = defaultChoiceLabels.map(
+		(label) => screen.getByLabelText(label) as HTMLInputElement,
+	);
+
+	t.false(apple.checked);
+	t.false(banana.checked);
+	t.false(greenBean.checked);
+	t.false(tomato.checked);
+
+	await user.click(banana);
+	t.false(apple.checked);
+	t.true(banana.checked);
+	t.false(greenBean.checked);
+	t.false(tomato.checked);
+
+	await user.click(tomato);
+	t.false(apple.checked);
+	t.false(banana.checked);
+	t.false(greenBean.checked);
+	t.true(tomato.checked);
+});
+
+test('`ChoiceField` controls the checked state of checkbox choices', async (t) => {
+	const user = userEvent.setup();
+
+	render(
+		<ChoiceField multiple label={defaultLabel}>
+			{defaultChoices}
+		</ChoiceField>,
+	);
+
+	const [apple, banana, greenBean, tomato] = defaultChoiceLabels.map(
+		(label) => screen.getByLabelText(label) as HTMLInputElement,
+	);
+
+	await user.click(apple);
+	await user.click(banana);
+	t.true(apple.checked);
+	t.true(banana.checked);
+	t.false(greenBean.checked);
+	t.false(tomato.checked);
+
+	await user.click(apple);
+	t.false(apple.checked);
+	t.true(banana.checked);
 });
 
 test('choice objects are rendered as choices', (t) => {

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -65,6 +65,16 @@ export const RadioGroup = {
 	},
 } satisfies GroupStory;
 
+export const RadioGroupWithArray = {
+	render: (args) => (
+		<RadioGroupComp {...args}>{fruits.map(({ children }) => children)}</RadioGroupComp>
+	),
+	args: {
+		label: 'Choose your favorite fruit',
+		name: 'fruit',
+	},
+} satisfies GroupStory;
+
 export const ControlledRadioGroup = {
 	render: (args) => {
 		const { selected, formChangeHandler } = useSelect();


### PR DESCRIPTION
When user press tab, focus moves to first Radio button in the group and when user press down arrow key, focus shift to next available Radio button but it keep selected the previous radio button. This is happening only very first time and later it works as expected. [moving selection along with focus].