### PR TITLE
fix: remove focus highlight in dropdown options

### DIFF
--- a/packages/core/src/a11y/index.scss
+++ b/packages/core/src/a11y/index.scss
@@ -10,13 +10,19 @@
 
 /// Create a focus halo from an inner and outer ring color.
 @function focus-halo(
+	$is-inset: false,
 	$inner-color: var(--nds-background-color),
 	$outer-color: var(--nds-focus-color),
 ) {
-	@return (
-		0 0 0 1px #{$inner-color},
-		0 0 0 3px #{$outer-color},
-	);
+	$inner-shadow: 0 0 0 1px #{$inner-color};
+	$outer-shadow: 0 0 0 3px #{$outer-color};
+
+	@if $is-inset {
+		$inner-shadow: $inner-shadow;
+		$outer-shadow: inset 0 0 0 2px $outer-color;
+	}
+
+	@return $inner-shadow, $outer-shadow;
 }
 
 // Create a focus ring with the specified color.
@@ -61,6 +67,13 @@
 /// to be applied in addition to the focus indicator.
 @mixin focus-halo($current-shadows...) {
 	@include -focus(focus-halo(), $current-shadows...);
+}
+
+/// A box shadow focus indicator that is inset from the focused element.
+/// @param {box-shadow[]} $current-shadows... - Zero or more additional shadows
+/// to be applied in addition to the focus indicator.
+@mixin focus-inset-halo($current-shadows...) {
+	@include -focus(focus-halo(true), $current-shadows...);
 }
 
 /// A box shadow focus indicator that is directly attached to the focused element.

--- a/packages/core/src/components/dropdown/index.scss
+++ b/packages/core/src/components/dropdown/index.scss
@@ -4,14 +4,13 @@
 @use '../../spacing';
 @use '../../type';
 @use '../../util';
+@use '../../a11y';
 
 @mixin base {
 	--nds-dropdown-border-width: #{tokens.$border-width};
 	--nds-dropdown-listbox-shadow: #{tokens.$listbox-shadow};
 	--nds-dropdown-options-max-display: #{tokens.$options-max-display};
 	--nds-dropdown-option-hover-color: #{tokens.$option-hover-color};
-	--nds-dropdown-option-hover-focus-color: #{tokens.$option-hover-focus-color};
-	--nds-dropdown-option-focus-color: #{tokens.$option-focus-color};
 	--nds-dropdown-option-padding-y: #{tokens.$option-padding-y};
 	--nds-dropdown-option-padding-x: #{tokens.$option-padding-x};
 	--nds-dropdown-option-font-size: #{tokens.$option-font-size};
@@ -68,8 +67,6 @@
 
 @mixin listbox {
 	--nds-option-hover-color: var(--nds-base-color-20);
-	--nds-option-hover-focus-color: var(--nds-base-color-30);
-	--nds-option-focus-color: var(--nds-focus-color-background);
 	--nds-option-padding-y: var(--nds-spacing-2);
 	--nds-option-padding-x: var(--nds-spacing-3);
 	--nds-option-marker-padding-x: calc(var(--nds-option-padding-x) / 2);
@@ -91,13 +88,8 @@
 	outline: none;
 	align-items: center;
 
-	&:focus {
-		background-color: var(--nds-dropdown-option-focus-color);
-		box-shadow: none;
-	}
-
-	&:hover:focus {
-		background-color: var(--nds-dropdown-option-hover-focus-color);
+	&:focus-visible {
+		@include a11y.focus-inset-halo;
 	}
 
 	&:not(:disabled):not([aria-disabled='true']):hover {


### PR DESCRIPTION
When the user clicks the dropdown the first menu item is always highlighted even when the user is not hovering on the option. This highlight should be removed and it should only appear if the menu item is selected.