### PR TITLE
fix(react): fix choice not calling `onChange`

### DIFF
--- a/packages/react/src/components/ChoiceField/ChoiceField.tsx
+++ b/packages/react/src/components/ChoiceField/ChoiceField.tsx
@@ -88,26 +88,33 @@ export const ChoiceField = React.forwardRef<HTMLFieldSetElement, ChoiceFieldProp
 				// coerce into a list of `<Choice>` elements
 				return React.Children.map(children, (child, idx) => {
 					if (Array.isArray(child)) return childMap(child);
+					const updateCheckedIndexes = () => {
+						setCheckedIndexes((prev) => {
+							if (multiple) {
+								return {
+									...prev,
+									[idx]: prev ? !prev[idx] : true,
+								};
+							}
+							return { [idx]: true };
+						});
+					};
+
 					const baseProps: ChoiceProps = {
 						name: name || id,
 						type,
-						onChange: () =>
-							setCheckedIndexes((prev) => {
-								if (multiple) {
-									return {
-										...prev,
-										[idx]: prev ? !prev[idx] : true,
-									};
-								}
-								return { [idx]: true };
-							}),
 					};
 
 					let value: string | number;
 					let props: ChoiceProps;
 					if (typeof child === 'string' || typeof child === 'number') {
 						value = child;
-						props = { ...baseProps, children: child, checked: checkedIndexes?.[idx] };
+						props = {
+							...baseProps,
+							children: child,
+							checked: checkedIndexes?.[idx],
+							onChange: updateCheckedIndexes,
+						};
 					} else if (React.isValidElement<ChoiceProps>(child)) {
 						value = (child.props.value || child.props.children || '').toString();
 
@@ -118,7 +125,14 @@ export const ChoiceField = React.forwardRef<HTMLFieldSetElement, ChoiceFieldProp
 							isChecked = child.props.checked;
 						}
 
-						props = { ...child.props, ...baseProps, checked: isChecked };
+						const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+							if (child.props.onChange) {
+								child.props.onChange(e);
+							}
+							updateCheckedIndexes();
+						};
+
+						props = { ...child.props, ...baseProps, checked: isChecked, onChange: onChangeHandler };
 					} else {
 						throw new Error('invalid children');
 					}

--- a/packages/react/src/components/ChoiceField/index.test.tsx
+++ b/packages/react/src/components/ChoiceField/index.test.tsx
@@ -174,6 +174,25 @@ test('`ChoiceField` controls the checked state of checkbox choices', async (t) =
 	t.true(banana.checked);
 });
 
+test('calls the `onChange` prop when a choice value changes', async (t) => {
+	const user = userEvent.setup();
+	let onChangeCalled = false;
+	const onChange = () => {
+		onChangeCalled = true;
+	};
+
+	render(
+		<ChoiceField label={defaultLabel}>
+			{defaultChoices.map((choice) => (
+				<Choice key={choice.props.value} {...choice.props} onChange={onChange} />
+			))}
+		</ChoiceField>,
+	);
+
+	await user.click(screen.getByLabelText(defaultChoiceLabels[0]));
+	t.true(onChangeCalled);
+});
+
 test('choice objects are rendered as choices', (t) => {
 	const choiceObjects = defaultChoiceLabels.map((label, i) => ({
 		children: label,


### PR DESCRIPTION
Fixes a bug where the Choice component doesn't call the `onChange` function it receives as prop